### PR TITLE
Feature/change nginx annotations handling

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
   - name: Lester Guerzon
     email: lester@pidnull.io
     url: https://github.com/guerzon
-version: 0.2.0
+version: 0.3.0

--- a/README.md
+++ b/README.md
@@ -238,21 +238,22 @@ Detailed configuration options can be found in the [Storage Configuration](#stor
 
 ### Exposure Parameters
 
-| Name                            | Description                                                                    | Value                    |
-| ------------------------------- | ------------------------------------------------------------------------------ | ------------------------ |
-| `ingress.enabled`               | Deploy an ingress resource.                                                    | `false`                  |
-| `ingress.class`                 | Ingress resource class                                                         | `nginx`                  |
-| `ingress.additionalAnnotations` | Additional annotations for the ingress resource.                               | `{}`                     |
-| `ingress.tls`                   | Enable TLS on the ingress resource.                                            | `true`                   |
-| `ingress.hostname`              | Hostname for the ingress.                                                      | `warden.contoso.com`     |
-| `ingress.path`                  | Default application path for the ingress                                       | `/`                      |
-| `ingress.pathWs`                | Path for the websocket ingress                                                 | `/notifications/hub`     |
-| `ingress.pathType`              | Path type for the ingress                                                      | `ImplementationSpecific` |
-| `ingress.pathTypeWs`            | Path type for the ingress                                                      | `ImplementationSpecific` |
-| `ingress.tlsSecret`             | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                     |
-| `ingress.nginxAllowList`        | Comma-separated list of IP addresses and subnets to allow.                     | `""`                     |
-| `service.type`                  | Service type                                                                   | `ClusterIP`              |
-| `service.annotations`           | Additional annotations for the vaultwarden service                             | `{}`                     |
+| Name                              | Description                                                                    | Value                    |
+| --------------------------------- | ------------------------------------------------------------------------------ | ------------------------ |
+| `ingress.enabled`                 | Deploy an ingress resource.                                                    | `false`                  |
+| `ingress.class`                   | Ingress resource class                                                         | `nginx`                  |
+| `ingress.nginxIngressAnnotations` | Add nginx specific ingress annotations                                         | `true`                   |
+| `ingress.additionalAnnotations`   | Additional annotations for the ingress resource.                               | `{}`                     |
+| `ingress.tls`                     | Enable TLS on the ingress resource.                                            | `true`                   |
+| `ingress.hostname`                | Hostname for the ingress.                                                      | `warden.contoso.com`     |
+| `ingress.path`                    | Default application path for the ingress                                       | `/`                      |
+| `ingress.pathWs`                  | Path for the websocket ingress                                                 | `/notifications/hub`     |
+| `ingress.pathType`                | Path type for the ingress                                                      | `ImplementationSpecific` |
+| `ingress.pathTypeWs`              | Path type for the ingress                                                      | `ImplementationSpecific` |
+| `ingress.tlsSecret`               | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                     |
+| `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                     |
+| `service.type`                    | Service type                                                                   | `ClusterIP`              |
+| `service.annotations`             | Additional annotations for the vaultwarden service                             | `{}`                     |
 
 
 ### Database Configuration

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- if .Values.ingress.additionalAnnotations }}
     {{- toYaml .Values.ingress.additionalAnnotations | nindent 4 }}
     {{- end }}
-    {{- if eq "nginx" .Values.ingress.class }}
+    {{- if .Values.ingress.nginxIngressAnnotations }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "Request-Id: $req_id";
     nginx.ingress.kubernetes.io/connection-proxy-header: "keep-alive"

--- a/values.yaml
+++ b/values.yaml
@@ -81,11 +81,15 @@ ingress:
   ##
   enabled: false
   ## @param ingress.class Ingress resource class
-  ## To use ingress-nginx, set class to "nginx", or "alb" for AWS LB controller.
+  ## The Ingress class to use, e. g. "nginx" for a nginx ingress controller or "alb" for a AWS LB controller.
   #
   class: "nginx"
-  ## @param ingress.additionalAnnotations Additional annotations for the ingress resource.
+  ## @param ingress.nginxIngressAnnotations Add nginx specific ingress annotations
+  ## This annotations are only makes sense for the kubernetes nginx ingress controller (https://kubernetes.github.io/ingress-nginx/)
   ##
+  nginxIngressAnnotations: true
+  ## @param ingress.additionalAnnotations Additional annotations for the ingress resource.
+  ## 
   additionalAnnotations: {}
   ## @param ingress.tls Enable TLS on the ingress resource.
   ##


### PR DESCRIPTION
It would be nice to have the nginx annotations with ingress classes, that are named other than 'nginx'.

In my case I have 2 nginx controllers installed. One controller is responsible für public workloads and its ingress class is called 'nginx-public'. The other one is for internal workloads. So I have to choose 'nginx-plublic' for my ingress class, but I want to have the nginx annotations in place as well. 