### PR TITLE
Init and sidecar containers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
   - name: Lester Guerzon
     email: lester@pidnull.io
     url: https://github.com/guerzon
-version: 0.3.0
+version: 0.4.0

--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ Detailed configuration options can be found in the [Storage Configuration](#stor
 | `storage.dataDir` | Specify the data directory                  | `/data`   |
 
 
+### Extra containers Configuration
+
+| Name             | Description                                                     | Value |
+| ---------------- | --------------------------------------------------------------- | ----- |
+| `initContainers` | extra init containers for initializing the vaultwarden instance | `[]`  |
+| `sidecars`       | extra containers running alongside the vaultwarden instance     | `[]`  |
+
+
 ## Uninstall
 
 To uninstall/delete the `vaultwarden-demo` release:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -18,6 +18,10 @@ spec:
         app: vaultwarden
         app.kubernetes.io/component: vaultwarden
     spec:
+      initContainers:
+        {{- if .Values.initContainers }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- end }}
       containers:
         - image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -60,6 +64,9 @@ spec:
             requests:
               cpu: 50m
               memory: 256Mi
+        {{- if .Values.sidecars }}
+        {{- toYaml .Values.sidecars | nindent 8 }}
+        {{- end }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -89,7 +89,7 @@ ingress:
   ##
   nginxIngressAnnotations: true
   ## @param ingress.additionalAnnotations Additional annotations for the ingress resource.
-  ## 
+  ##
   additionalAnnotations: {}
   ## @param ingress.tls Enable TLS on the ingress resource.
   ##
@@ -217,3 +217,14 @@ storage:
   ## @param storage.dataDir Specify the data directory
   ##
   dataDir: "/data"
+
+## @section Extra containers Configuration
+##
+
+## @param initContainers extra init containers for initializing the vaultwarden instance
+##
+initContainers: []
+
+## @param sidecars extra containers running alongside the vaultwarden instance
+##
+sidecars: []


### PR DESCRIPTION
I need to run my backup and restore containers inside the vaultwarden pod and it would be nice to have support in the helm chart for this.