### PR TITLE
Added parameters signupsAllowed and invitationsAllowed

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
   - name: Lester Guerzon
     email: lester@pidnull.io
     url: https://github.com/guerzon
-version: 0.4.0
+version: 0.5.0

--- a/README.md
+++ b/README.md
@@ -225,15 +225,17 @@ Detailed configuration options can be found in the [Storage Configuration](#stor
 
 ### Security settings
 
-| Name                    | Description                                                         | Value               |
-| ----------------------- | ------------------------------------------------------------------- | ------------------- |
-| `adminToken`            | The admin token used for /admin                                     | `R@ndomToken$tring` |
-| `signupDomains`         | List of domain names for users allowed to register                  | `contoso.com`       |
-| `signupsVerify`         | Whether to require account verification for newly-registered users. | `true`              |
-| `showPassHint`          | Whether a password hint should be shown in the page.                | `false`             |
-| `fullnameOverride`      | String to override the application name.                            | `""`                |
-| `serviceAccount.create` | Create a service account                                            | `true`              |
-| `serviceAccount.name`   | Name of the service account to create                               | `vaultwarden-svc`   |
+| Name                    | Description                                                            | Value               |
+| ----------------------- | ---------------------------------------------------------------------- | ------------------- |
+| `adminToken`            | The admin token used for /admin                                        | `R@ndomToken$tring` |
+| `signupsAllowed`        | Whether new users can register via the web interface                   | true                |
+| `invitationsAllowed`    | Whether organization admins can send invitations to register new users | true                |
+| `signupDomains`         | List of domain names for users allowed to register                     | `contoso.com`       |
+| `signupsVerify`         | Whether to require account verification for newly-registered users.    | `true`              |
+| `showPassHint`          | Whether a password hint should be shown in the page.                   | `false`             |
+| `fullnameOverride`      | String to override the application name.                               | `""`                |
+| `serviceAccount.create` | Create a service account                                               | `true`              |
+| `serviceAccount.name`   | Name of the service account to create                                  | `vaultwarden-svc`   |
 
 
 ### Exposure Parameters

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -34,6 +34,8 @@ data:
   ROCKET_PORT: {{ .Values.rocket.port | quote }}
   ROCKET_WORKERS: {{ .Values.rocket.workers | quote }}
   SHOW_PASSWORD_HINT: {{ .Values.showPassHint | quote }}
+  SIGNUPS_ALLOWED: {{ .Values.signupsAllowed | quote }}
+  INVITATIONS_ALLOWED: {{ .Values.invitationsAllowed | quote }}
   SIGNUPS_DOMAINS_WHITELIST: {{ .Values.signupDomains | quote }}
   SIGNUPS_VERIFY: {{ .Values.signupsVerify | quote }}
   WEB_VAULT_ENABLED: {{ .Values.webVaultEnabled | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -51,6 +51,19 @@ webVaultEnabled: "true"
 ## @param adminToken The admin token used for /admin
 ##
 adminToken: "R@ndomToken$tring"
+## @param signupsAllowed By default, anyone who can access your instance can register for a new account.
+## To disable this, set this parameter to false. Even when signupsAllowed=false, an existing user who is
+## an organization owner or admin can still invite new users. If you want to disable this as well, set
+## invitationsAllowed to false. The vaultwarden admin can invite anyone via the admin page, regardless
+## of any of the restrictions above
+##
+## If signupDomains is set, then the value of signupsAllowed is ignored
+signupsAllowed: true
+## @param invitationsAllowed Even when registration is disabled, organization administrators or owners can
+## invite users to join organization. After they are invited, they can register with the invited email even
+## if signupsAllowed is actually set to false. You can disable this functionality completely by setting
+## invitationsAllowed env variable to false
+invitationsAllowed: true
 ## @param signupDomains List of domain names for users allowed to register
 ##
 signupDomains: "contoso.com"


### PR DESCRIPTION
I'm using Vaultwarden in my private homelab and I don't want new users to register in my instance. All users on my instance are created from the admin page. Vaultwarden supports this setup by setting the environment variables `signupsAllowed` and `invitationsAllowed` to false, so I've added them to the Helm chart as well.