### PR TITLE
configurable annotations for volumeClaimTemplates

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -92,6 +92,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: vaultwarden-data
+        {{- if .Values.storage.annotations }}
+        annotations:
+          {{- toYaml .Values.storage.annotations | nindent 12 }}
+        {{- end }}
       spec:
         accessModes:
           - "ReadWriteOnce"


### PR DESCRIPTION
I added the option to configure anntoations for volumeClaimTemplates via values, since I needed this for my own setup. 