### PR TITLE
Permit to add additional volumes for sidecar containers in statefulset.yaml

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -82,6 +82,9 @@ spec:
         {{- if .Values.sidecars }}
         {{- toYaml .Values.sidecars | nindent 8 }}
         {{- end }}
+        {{- if .Values.additionalVolumes }}
+        {{- toYaml .Values.additionalVolumes | nindent 6 }}
+        {{- end }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}


### PR DESCRIPTION
I'm using [vaultwarden-backup](https://github.com/ttionya/vaultwarden-backup) as a sidecar container, but it also needs to mount a second volume for its configuration. At the moment I can't do it with your chart. 

I achived that with the little modification I'm proposing
Then, in my values.yaml I'm using it as I would do in a normal statefulset:

```
additionalVolumes:
  volumes:
    - configMap:
        name: vaultwarden-backup-rclone-config
      name: vaultwarden-backup-rclone-config
```
