### PR TITLE
fix: Allow specyfing tlsSecret not only for nginx

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -44,9 +44,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
-      {{- if eq "nginx" .Values.ingress.class }}
       secretName: {{ .Values.ingress.tlsSecret }}
-      {{- end }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.hostname | quote }}


### PR DESCRIPTION
When using `ingressClass` for example `traefik` along with `cert-manager` it is impossible to generate certificate.

Allowing setting up `secretName` for any type of `ingressClass` fixes it.