### PR TITLE
fix PVC: instead using storageClass with name 'default' use default storageClass

### DIFF
--- a/charts/vaultwarden/templates/statefulset.yaml
+++ b/charts/vaultwarden/templates/statefulset.yaml
@@ -129,5 +129,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.storage.size }}
-        storageClassName: {{ default "default" .Values.storage.class }}
+        {{- if .Values.storage.class }}
+        storageClassName: {{ .Values.storage.class | quote }}
+        {{- end }}
   {{- end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -282,7 +282,7 @@ storage:
   size: "15Gi"
   ## @param storage.class Specify the storage class
   ##
-  class: "default"
+  class: ""
   ## @param storage.dataDir Specify the data directory
   ##
   dataDir: "/data"


### PR DESCRIPTION
fix issue #29 