### PR TITLE
Allow Signup domains not to be set

### DIFF
--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -32,7 +32,9 @@ data:
   SHOW_PASSWORD_HINT: {{ .Values.showPassHint | quote }}
   SIGNUPS_ALLOWED: {{ .Values.signupsAllowed | quote }}
   INVITATIONS_ALLOWED: {{ .Values.invitationsAllowed | quote }}
+  {{- if .Values.signupDomains }}
   SIGNUPS_DOMAINS_WHITELIST: {{ .Values.signupDomains | quote }}
+  {{- end }}
   SIGNUPS_VERIFY: {{ .Values.signupsVerify | quote }}
   WEB_VAULT_ENABLED: {{ .Values.webVaultEnabled | quote }}
   {{- if .Values.logging.enabled }}
@@ -41,3 +43,6 @@ data:
   {{- end }}
   DB_CONNECTION_RETRIES: {{ .Values.database.connectionRetries | quote }}
   DATABASE_MAX_CONNS: {{ .Values.database.maxConnections | quote }}
+  INVITATION_ORG_NAME: {{ .Values.invitationOrgName | quote }}
+  ICON_BLACKLIST_NON_GLOBAL_IPS: {{ .Values.iconBlacklistNonGlobalIps | quote }}
+  IP_HEADER: {{ .Values.ipHeader | quote }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -85,7 +85,7 @@ signupsAllowed: true
 invitationsAllowed: true
 ## @param signupDomains List of domain names for users allowed to register
 ##
-signupDomains: "contoso.com"
+signupDomains: ""
 ## @param signupsVerify Whether to require account verification for newly-registered users.
 ##
 signupsVerify: "true"
@@ -95,6 +95,19 @@ showPassHint: "false"
 ## @param fullnameOverride String to override the application name.
 ##
 fullnameOverride: ""
+
+## @param invitationOrgName String Name shown in the invitation emails that don't come from a specific organization
+##
+invitationOrgName: "Vaultwarden"
+
+## @param iconBlacklistNonGlobalIps Whether block non-global IPs.
+## Useful to secure your internal environment: See https://en.wikipedia.org/wiki/Reserved_IP_addresses for a list of IPs which it will block
+iconBlacklistNonGlobalIps: "true"
+
+## @param ipHeader Client IP Header, used to identify the IP of the client
+##
+ipHeader: "X-Real-IP"
+
 ## @param serviceAccount.create Create a service account
 ## @param serviceAccount.name Name of the service account to create
 ##


### PR DESCRIPTION
Allow unset signup domains

Some options:
    INVITATION_ORG_NAME
    ICON_BLACKLIST_NON_GLOBAL_IPS
    IP_HEADER
    
See description in Admin Panel -> Settings