### PR TITLE
Short service name

### DIFF
--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -59,7 +59,7 @@ spec:
           pathType: {{ $ingress.pathType }}
           backend:
             service:
-              name: {{ include "vaultwarden.fullname" . }}
+              name: {{ .Values.service.name }}
               port:
                 name: "http"
         {{- if .Values.websocket.enabled }}
@@ -67,7 +67,7 @@ spec:
           pathType: {{ $ingress.pathTypeWs }}
           backend:
             service:
-              name: {{ include "vaultwarden.fullname" . }}
+              name: {{ .Values.service.name }}
               port:
                 name: "websocket"
         {{- end }}

--- a/charts/vaultwarden/templates/service.yaml
+++ b/charts/vaultwarden/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "vaultwarden.fullname" . }}
+  name: {{ .Values.service.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: vaultwarden

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -170,6 +170,10 @@ service:
   ##
   labels: {}
 
+  ## @param service.name Vaultwarden service/ingress name
+  ##
+  name: vaultwarden
+
 ## @section Database Configuration
 ##
 database:


### PR DESCRIPTION
Set a short service name, since one inferred from helm chart is long and clumsy

In case external ingress is used, templating causes additional pain for helmfile templated charts. Since it is included in the namespace already, while service name has it twice. Unnecessary in this case since it is within namespace scope already