### PR TITLE
Fix labels to enable upgrading by changing the image tag

### DIFF
--- a/charts/vaultwarden/templates/_helpers.tpl
+++ b/charts/vaultwarden/templates/_helpers.tpl
@@ -37,7 +37,9 @@ Common labels
 {{- define "vaultwarden.labels" -}}
 helm.sh/chart: {{ include "vaultwarden.chart" . }}
 {{ include "vaultwarden.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 


### PR DESCRIPTION
This fixes issue #33 by removing the `image.tag` from the labels in the stateful set.