### PR TITLE
Update to use only one volumeMounts key

### DIFF
--- a/charts/vaultwarden/templates/statefulset.yaml
+++ b/charts/vaultwarden/templates/statefulset.yaml
@@ -110,13 +110,14 @@ spec:
               path: /alive
               port: 8080
               initialDelaySeconds: 5
-          {{- if .Values.data }}
+          {{- if or (.Values.data) (.Values.attachments) }}
           volumeMounts:
+          {{- end }}
+          {{- if .Values.data }}
             - name: {{ .Values.data.name }}
               mountPath: {{ default "/data" .Values.data.path }}
           {{- end }}
           {{- if .Values.attachments }}
-          volumeMounts:
             - name: {{ .Values.attachments.name }}
               mountPath: {{ default "/data/attachments" .Values.attachments.path }}
           {{- end }}


### PR DESCRIPTION
Noticed that if you specify both attachments and data it will insert a duplicate volumeMounts key and corrected this to only use one. 