### PR TITLE
Automatically use Deployment instead of StatefulSet

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 sources:
   - https://github.com/guerzon/vaultwarden
   - https://github.com/dani-garcia/vaultwarden
-appVersion: 1.29.2
+appVersion: 1.30.1
 maintainers:
   - name: guerzon
     email: guerzon@proton.me

--- a/charts/vaultwarden/templates/_helpers.tpl
+++ b/charts/vaultwarden/templates/_helpers.tpl
@@ -66,3 +66,29 @@ Return the database string
 {{- $var := print .Values.database.type "://" .Values.database.username ":" .Values.database.password "@" .Values.database.host (include "dbPort" . ) "/" .Values.database.dbName }}
 {{- printf "%s" $var }}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for podDisruptionBudget.
+*/}}
+{{- define "podDisruptionBudget.apiVersion" -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version -}}
+{{- print "policy/v1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine whether to use deployment or statefulset
+*/}}
+{{- define "vaultwarden.deploymentKind" -}}
+{{- if .Values.deploymentKind }}
+{{- .Values.deploymentKind }}
+{{- else }}
+{{- if (and .Values.data (ne .Values.database.type "default")) }}
+{{- "Deployment" }}
+{{- else }}
+{{- "StatefulSet" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -1,0 +1,141 @@
+{{- define "vaultwarden.podSpec" }}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+affinity:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.initContainers }}
+initContainers:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+containers:
+  - image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    name: vaultwarden
+    envFrom:
+      - configMapRef:
+          name: {{ include "vaultwarden.fullname" . }}
+    env:
+      {{- if or (.Values.smtp.username.value) (.Values.smtp.username.existingSecretKey )}}
+      - name: SMTP_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: {{ default (include "vaultwarden.fullname" .) .Values.smtp.existingSecret }}
+            key: {{ default "SMTP_USERNAME" .Values.smtp.username.existingSecretKey }}
+      {{- end }}
+      {{- if or (.Values.smtp.password.value) (.Values.smtp.password.existingSecretKey )}}
+      - name: SMTP_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ default (include "vaultwarden.fullname" .) .Values.smtp.existingSecret }}
+            key: {{ default "SMTP_PASSWORD" .Values.smtp.password.existingSecretKey }}
+      {{- end }}
+      {{- if .Values.adminToken }}
+      - name: ADMIN_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ default (include "vaultwarden.fullname" .) .Values.adminToken.existingSecret }}
+            key: {{ default "ADMIN_TOKEN" .Values.adminToken.existingSecretKey }}
+      {{- else }}
+      - name: DISABLE_ADMIN_TOKEN
+        value: "true"
+      {{- end }}
+      {{- if ne "default" .Values.database.type }}
+      - name: DATABASE_URL
+        {{- if .Values.database.existingSecret }}
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.database.existingSecret }}
+            key: {{ .Values.database.existingSecretKey }}
+        {{- else }}
+        {{- if .Values.database.uriOverride }}
+        value: {{ .Values.database.uriOverride }}
+        {{- else }}
+        value: {{ include "dbString" . | quote }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+    ports:
+      - containerPort: 8080
+        name: http
+        protocol: TCP
+      - containerPort: {{ .Values.websocket.port }}
+        name: websocket
+        protocol: TCP
+    {{- if or (.Values.data) (.Values.attachments) }}
+    volumeMounts:
+      {{- with .Values.data }}
+      - name: {{ .name }}
+        mountPath: {{ default "/data" .path }}
+      {{- end }}
+      {{- with .Values.attachments }}
+      - name: {{ .name }}
+        mountPath: {{ default "/data/attachments" .path }}
+      {{- end }}
+    {{- end }}
+    resources:
+    {{- toYaml .Values.resources | nindent 12 }}
+    {{- with .Values.securityContext }}
+    securityContext:
+    {{- toYaml . | nindent 12 }}
+    {{- end }}
+    {{- if .Values.livenessProbe.enabled }}
+    livenessProbe:
+      httpGet:
+        path: /alive
+      initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+      periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+      timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+      successThreshold: {{ .Values.livenessProbe.successThreshold }}
+      failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+    {{- else }}
+    {{- with .Values.customLivenessProbe }}
+    livenessProbe:
+    {{- toYaml . | nindent 12 }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.readinessProbe.enabled }}
+    readinessProbe:
+      httpGet:
+        path: /alive
+        port: http
+      initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+      periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+      timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+      successThreshold: {{ .Values.readinessProbe.successThreshold }}
+      failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+    {{- else }}
+    {{- with .Values.customReadinessProbe }}
+    readinessProbe:
+    {{- toYaml . | nindent 12 }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.startupProbe.enabled }}
+    startupProbe:
+      httpGet:
+        path: /alive
+      initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+      periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+      timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+      successThreshold: {{ .Values.startupProbe.successThreshold }}
+      failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+    {{- else }}
+    {{- with .Values.customStartupProbe }}
+    startupProbe:
+    {{- toYaml . | nindent 12 }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.sidecars }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- if .Values.serviceAccount.create }}
+serviceAccountName: {{ .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/vaultwarden/templates/_pvcSpec.tpl
+++ b/charts/vaultwarden/templates/_pvcSpec.tpl
@@ -1,0 +1,38 @@
+{{- define "vaultwarden.pvcSpec" }}
+{{- if (or .Values.data .Values.attachments) }}
+volumeClaimTemplates:
+  {{- with .Values.data }}
+  - metadata:
+      name: {{ .name }}
+      labels:
+        {{- include "vaultwarden.labels" $ | nindent 10 }}
+      annotations:
+        meta.helm.sh/release-name: {{ $.Release.Name | quote }}
+        meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: {{ .size }}
+      {{- with .class }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
+  {{- end }}
+  {{- with .Values.attachments }}
+  - metadata:
+      name: {{ .name }}
+      labels:
+        {{- include "vaultwarden.labels" $ | nindent 10 }}
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: {{ .size }}
+      {{- with .class }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app.kubernetes.io/component: vaultwarden
     {{- include "vaultwarden.labels" . | nindent 4 }}
+{{- with .Values.configMapAnnotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+{{- end }}
 data:
   DOMAIN: {{ .Values.domain | quote }}
   {{- if and .Values.smtp.host .Values.smtp.from }}
@@ -32,6 +36,7 @@ data:
   {{- if .Values.attachments }}
   ATTACHMENTS_FOLDER: {{ default "/data/attachments" .Values.attachments.path | quote }}
   {{- end }}
+  ROCKET_ADDRESS: {{ .Values.rocket.address | quote }}
   ROCKET_PORT: {{ .Values.rocket.port | quote }}
   ROCKET_WORKERS: {{ .Values.rocket.workers | quote }}
   SHOW_PASSWORD_HINT: {{ .Values.showPassHint | quote }}

--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -1,6 +1,6 @@
-{{- if eq (include "vaultwarden.deploymentKind" .) "StatefulSet" }}
+{{- if eq (include "vaultwarden.deploymentKind" .) "Deployment" }}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "vaultwarden.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -15,14 +15,13 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  serviceName: vaultwarden
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: vaultwarden
       {{- include "vaultwarden.selectorLabels" . | nindent 6 }}
   {{- with .Values.strategy }}
-  updateStrategy:
+  strategy:
     {{- . | toYaml | nindent 8 }}
   {{- end }}
   template:
@@ -41,8 +40,11 @@ spec:
         {{- end }}
     spec:
       {{- include "vaultwarden.podSpec" . | nindent 6 }}
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Retain
-    whenScaled: Retain
-  {{- include "vaultwarden.pvcSpec" . | nindent 2 }}
+      volumes:
+        {{- range $pvc := (fromYaml (include "vaultwarden.pvcSpec" .)).volumeClaimTemplates }}
+        {{- $newName := printf "%s-%s-0" $pvc.metadata.name $.Release.Name }}
+        - name: {{ $pvc.metadata.name }}
+          persistentVolumeClaim:
+            claimName: {{ $newName }}
+        {{- end }}
 {{- end }}

--- a/charts/vaultwarden/templates/poddisruptionbudget.yaml
+++ b/charts/vaultwarden/templates/poddisruptionbudget.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- $component := .Values.podDisruptionBudget }}
+apiVersion: {{ include "podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: vaultwarden
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: vaultwarden
+    app.kubernetes.io/name: vaultwarden
+    app.kubernetes.io/part-of: vaultwarden
+spec:
+  {{- with $component.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  {{- with $component.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      k8s-app: vaultwarden
+{{- end }}

--- a/charts/vaultwarden/templates/pvc.yaml
+++ b/charts/vaultwarden/templates/pvc.yaml
@@ -1,0 +1,10 @@
+{{- if eq (include "vaultwarden.deploymentKind" .) "Deployment" }}
+{{- range $pvc := (fromYaml (include "vaultwarden.pvcSpec" .)).volumeClaimTemplates }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+{{- $newName := printf "%s-%s-0" $pvc.metadata.name $.Release.Name }}
+{{- $newPvc := merge (dict "metadata" (dict "name" $newName)) $pvc }}
+{{ $newPvc | toYaml }}
+{{- end }}
+{{- end }}

--- a/charts/vaultwarden/templates/secrets.yaml
+++ b/charts/vaultwarden/templates/secrets.yaml
@@ -13,7 +13,7 @@ data:
   SMTP_PASSWORD: {{ .Values.smtp.password.value | b64enc | quote }}
   SMTP_USERNAME: {{ .Values.smtp.username.value | b64enc | quote }}
   {{- end }}
-  {{- if ( .Values.adminToken ) }}
+  {{- if not ( .Values.adminToken.existingSecret ) }}
   ADMIN_TOKEN: {{ .Values.adminToken.value | b64enc | quote }}
   {{- end }}
 {{ end }}

--- a/charts/vaultwarden/templates/service.yaml
+++ b/charts/vaultwarden/templates/service.yaml
@@ -28,3 +28,6 @@ spec:
       protocol: TCP
       targetPort: {{ .Values.websocket.port }}
     {{- end }}
+{{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+{{- end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -11,7 +11,7 @@ image:
   ## @param image.tag Vaultwarden image tag
   ## Ref: https://hub.docker.com/r/vaultwarden/server/tags
   ##
-  tag: "1.29.2-alpine"
+  tag: "1.30.1-alpine"
   ## @param image.pullPolicy Vaultwarden image pull policy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -39,11 +39,17 @@ websocket:
 ## @param rocket.workers Rocket number of workers
 ##
 rocket:
+  address: "127.0.0.1"
   port: "8080"
   workers: "10"
 ## @param webVaultEnabled Enable Web Vault
 ##
 webVaultEnabled: "true"
+
+## @section Overwrite automatic deployment kind detection
+## Can be either Deployment or StatefulSet
+##
+deploymentKind: ""
 
 ## @section Pod configuration
 ##
@@ -172,6 +178,111 @@ ingress:
   ##   - Add support for using cert-manager.
   ##   - Support for multiple TLS hostnames.
   ##
+
+## @section Probe Parameters
+##
+
+## Liveness probe configuration
+##
+livenessProbe:
+  ## @param livenessProbe.enabled Enable liveness probe
+  ##
+  enabled: true
+  ## @param livenessProbe.initialDelaySeconds Delay before liveness probe is initiated
+  ##
+  initialDelaySeconds: 200
+  ## @param livenessProbe.timeoutSeconds How long to wait for the probe to succeed
+  ##
+  timeoutSeconds: 1
+  ## @param livenessProbe.periodSeconds How often to perform the probe
+  ##
+  periodSeconds: 10
+  ## @param livenessProbe.successThreshold Minimum consecutive successes for the probe to be considered successful
+  ##
+  successThreshold: 1
+  ## @param livenessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed
+  ##
+  failureThreshold: 10
+
+## Readiness probe configuration
+##
+readinessProbe:
+  ## @param readinessProbe.enabled Enable readiness probe
+  ##
+  enabled: true
+  ## @param readinessProbe.initialDelaySeconds Delay before readiness probe is initiated
+  ##
+  initialDelaySeconds: 5
+  ## @param readinessProbe.timeoutSeconds How long to wait for the probe to succeed
+  ##
+  timeoutSeconds: 1
+  ## @param readinessProbe.periodSeconds How often to perform the probe
+  ##
+  periodSeconds: 10
+  ## @param readinessProbe.successThreshold Minimum consecutive successes for the probe to be considered successful
+  ##
+  successThreshold: 1
+  ## @param readinessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed
+  ##
+  failureThreshold: 3
+
+
+## Startup probe configuration
+##
+startupProbe:
+  ## @param startupProbe.enabled Enable startup probe
+  ##
+  enabled: false
+  ## @param startupProbe.initialDelaySeconds Delay before startup probe is initiated
+  ##
+  initialDelaySeconds: 60
+  ## @param startupProbe.timeoutSeconds How long to wait for the probe to succeed
+  ##
+  timeoutSeconds: 1
+  ## @param startupProbe.periodSeconds How often to perform the probe
+  ##
+  periodSeconds: 10
+  ## @param startupProbe.successThreshold Minimum consecutive successes for the probe to be considered successful
+  ##
+  successThreshold: 1
+  ## @param startupProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed
+  ##
+  failureThreshold: 10
+
+## @param customLivenessProbe Custom configuration for liveness probe
+##
+customLivenessProbe: null
+#   httpGet:
+#     path: /
+#     port: http
+#   initialDelaySeconds: 60
+#   periodSeconds: 10
+#   successThreshold: 1
+#   failureThreshold: 10
+
+## @param customReadinessProbe Custom configuration for readiness probe
+##
+customReadinessProbe: null
+#   httpGet:
+#     path: /
+#     port: http
+#   initialDelaySeconds: 5
+#   periodSeconds: 10
+#   successThreshold: 1
+#   failureThreshold: 3
+
+## @param customStartupProbe Custom configuration for startup probe
+##
+customStartupProbe: null
+#   httpGet:
+#     path: /
+#     port: http
+#   initialDelaySeconds: 60
+#   periodSeconds: 10
+#   successThreshold: 1
+#   failureThreshold: 10
+
+securityContext: {}
 
 ## Service configuration
 service:
@@ -345,13 +456,13 @@ affinity: {}
 ##
 tolerations: []
 
-## @param statefulsetlabels Additional labels for the statefulset
+## @param commonLabels Additional labels for the deployment or statefulset
 ##
-statefulsetlabels: {}
+commonLabels: {}
 
-## @param statefulsetAnnotations Annotations for the statefulset
+## @param commonAnnotations Annotations for the deployment or statefulset
 ##
-statefulsetAnnotations: {}
+commonAnnotations: {}
 
 ## @param pushNotifications Enable mobile push notifications
 ## Supported since 1.29.0.
@@ -374,3 +485,20 @@ resources: {}
   # requests:
   #   cpu: 50m
   #   memory: 256Mi
+
+strategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+
+# PodDisruptionBudget settings
+podDisruptionBudget:
+  # -- enable PodDisruptionBudget
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  enabled: false
+  # -- Minimum number/percentage of pods that should remain scheduled.
+  # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
+  minAvailable: 1
+  # -- Maximum number/percentage of pods that may be made unavailable
+  maxUnavailable: null


### PR DESCRIPTION
Closes https://github.com/guerzon/vaultwarden/issues/4

When a persistent data storage and an external database are used automatically switch to use a Deployment instead of a StatefulSet. This can be manually overridden using the `deploymentKind` option.