### PR TITLE
Improved PVC configuration

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.18.0
+version: 0.18.1
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -208,13 +208,24 @@ data:
   path: "/srv/vaultwarden-data"
 ```
 
-To use persistent storage for attachments, set the `attachmenets` dictionary. Optionally set a different path. Note that by default, the path is `/data/attachments`.
+To use persistent storage for attachments, set the `attachments` dictionary. Optionally set a different path. Note that by default, the path is `/data/attachments`.
 
 ```yaml
 data:
   name: "vaultwarden-data"
   size: "15Gi"
   class: "local-path"
+```
+
+In case you want to keep the existing persistent volume claim during uninstall and redeployments, set the option `keepPvc: true`
+(This will be ignored for StatefulSets and is only relevant for `resourceType: Deployment`)
+
+```yaml
+data:
+  name: "vaultwarden-data"
+  size: "15Gi"
+  class: "local-path"
+  keepPvc: true
 ```
 
 ## Uninstall

--- a/charts/vaultwarden/templates/_pvcSpec.tpl
+++ b/charts/vaultwarden/templates/_pvcSpec.tpl
@@ -9,6 +9,9 @@ volumeClaimTemplates:
       annotations:
         meta.helm.sh/release-name: {{ $.Release.Name | quote }}
         meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}
+        {{- if .keepPvc }}
+        helm.sh/resource-policy: keep
+        {{- end }}
     spec:
       accessModes:
         - "ReadWriteOnce"

--- a/charts/vaultwarden/templates/_pvcSpec.tpl
+++ b/charts/vaultwarden/templates/_pvcSpec.tpl
@@ -27,6 +27,12 @@ volumeClaimTemplates:
       name: {{ .name }}
       labels:
         {{- include "vaultwarden.labels" $ | nindent 10 }}
+      annotations:
+        meta.helm.sh/release-name: {{ $.Release.Name | quote }}
+        meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}
+        {{- if .keepPvc }}
+        helm.sh/resource-policy: keep
+        {{- end }}
     spec:
       accessModes:
         - "ReadWriteOnce"

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -390,6 +390,7 @@ attachments: {}
   # size: "100Gi"
   # class: ""
   # path: /files
+  # keepPvc: false
 
 ## @section Logging Configuration
 ##

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -380,6 +380,7 @@ data: {}
   # size: "15Gi"
   # class: ""
   # path: "/data"
+  # keepPvc: false
 
 ## @param attachments Attachments directory configuration, refer to values.yaml for parameters.
 ## By default, attachments/ is located inside the data directory.


### PR DESCRIPTION
Improved PVC configuration to optionally keep the volume after uninstalling the deployment.

The new option `keepPvc: true` will make sure that the PVC will not be deleted when a chart deployment gets uninstalled and can be resused after a new deployment.
