### PR TITLE
Reduce the initialDelaySeconds values

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.18.0
+version: 0.18.1
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -194,7 +194,7 @@ livenessProbe:
   enabled: true
   ## @param livenessProbe.initialDelaySeconds Delay before liveness probe is initiated
   ##
-  initialDelaySeconds: 200
+  initialDelaySeconds: 5
   ## @param livenessProbe.timeoutSeconds How long to wait for the probe to succeed
   ##
   timeoutSeconds: 1
@@ -239,7 +239,7 @@ startupProbe:
   enabled: false
   ## @param startupProbe.initialDelaySeconds Delay before startup probe is initiated
   ##
-  initialDelaySeconds: 60
+  initialDelaySeconds: 5
   ## @param startupProbe.timeoutSeconds How long to wait for the probe to succeed
   ##
   timeoutSeconds: 1


### PR DESCRIPTION
The default initialDelaySeconds for the liveness and startup probes are too high for how quickly vaultwarden boots. I have therefore reduced them to 5 seconds.