### PR TITLE
Improved security configuration

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.18.1
+version: 0.18.2
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -11,6 +11,10 @@ affinity:
 tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- with .Values.podSecurityContext }}
+securityContext:
+  {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- with .Values.initContainers }}
 initContainers:
 {{- toYaml . | nindent 8 }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -253,7 +253,23 @@ startupProbe:
   ##
   failureThreshold: 10
 
+## Pod security options
+podSecurityContext: {}
+  # fsGroup: 1001
+  # supplementalGroups:
+  #   - 1001
+
+## Default security options to run vault as read only container without privilege escalation
 securityContext: {}
+  # allowPrivilegeEscalation: false
+  # privileged: false
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsGroup: 1001
+  # runAsUser: 1001
+  # capabilities:
+  #   drop:
+  #     - ALL
 
 ## Service configuration
 service:


### PR DESCRIPTION
If possbile a pod / container should never run with root privileges.
Beside securityContext the podSecurityContext was added as configuration option.
Additionally (working) example values are added for these 2 sections.

Limitation: This does only work for a new vaultwarden setup. If you upgrade from a previous chart version, you need to adapt permissions on the storage volume.
