### PR TITLE
Allow configuring experimental client feature flags

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.19.0
+version: 0.20.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -70,3 +70,6 @@ data:
   YUBICO_SERVER: {{ .Values.yubico.server | quote }}
   {{- end }}
   {{- end }}
+  {{- with .Values.experimentalClientFeatureFlags }}
+  EXPERIMENTAL_CLIENT_FEATURE_FLAGS: {{ . | quote }}
+  {{- end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -157,6 +157,14 @@ yubico:
   secretKey: ""
   server: ""
 
+## @param experimentalClientFeatureFlags Comma separated list of experimental features to enable in clients, make sure to check which features are already enabled by default (.env.template)
+## Possible values:
+##  - "autofill-overlay": Add an overlay menu to form fields for quick access to credentials.
+##  - "autofill-v2": Use the new autofill implementation.
+##  - "browser-fileless-import": Directly import credentials from other providers without a file.
+##  - "fido2-vault-credentials": Enable the use of FIDO2 security keys as second factor.
+experimentalClientFeatureFlags: null
+
 
 ## @section Exposure Parameters
 ##


### PR DESCRIPTION
With the latest vaultwarden version [1.30.2](https://github.com/dani-garcia/vaultwarden/releases/tag/1.30.2) it is possible to enable experimental client features using flags.
This comma separated list may be altered to enable additional features or disable features that are enabled by default.
The default value of `null` makes sure to use the default list of features included in the vaultwarden binary as this list might change with each release. 