### PR TITLE
feat: allow multiple ingress hostnames

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.22.0
+version: 0.22.1
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -416,29 +416,29 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 
 ### Exposure settings
 
-| Name                              | Description                                                                    | Value                                                   |
-| --------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------- |
-| `websocket.enabled`               | Enable websocket notifications                                                 | `true`                                                  |
-| `websocket.address`               | Websocket listen address                                                       | `0.0.0.0`                                               |
-| `websocket.port`                  | Websocket listen port                                                          | `3012`                                                  |
-| `rocket.address`                  | Address to bind to                                                             | `0.0.0.0`                                               |
-| `rocket.port`                     | Rocket port                                                                    | `8080`                                                  |
-| `rocket.workers`                  | Rocket number of workers                                                       | `10`                                                    |
-| `service.type`                    | Service type                                                                   | `ClusterIP`                                             |
-| `service.annotations`             | Additional annotations for the vaultwarden service                             | `{}`                                                    |
-| `service.labels`                  | Additional labels for the service                                              | `{}`                                                    |
-| `service.ipFamilyPolicy`          | IP family policy for the service                                               | `SingleStack`                                           |
-| `ingress.enabled`                 | Deploy an ingress resource.                                                    | `true`                                                  |
-| `ingress.class`                   | Ingress resource class                                                         | `nginx`                                                 |
-| `ingress.nginxIngressAnnotations` | Add nginx specific ingress annotations                                         | `true`                                                  |
-| `ingress.additionalAnnotations`   | Additional annotations for the ingress resource.                               | `{}`                                                    |
-| `ingress.labels`                  | Additional labels for the ingress resource.                                    | `{}`                                                    |
-| `ingress.tls`                     | Enable TLS on the ingress resource.                                            | `true`                                                  |
-| `ingress.hostname`                | Hostname for the ingress.                                                      | `warden.contoso.com`                                    |
-| `ingress.additionalHostnames`     | Additional hostnames for the ingress.                                          | `["prod-warden.contoso.com","vaultwarden.contoso.com"]` |
-| `ingress.path`                    | Default application path for the ingress                                       | `/`                                                     |
-| `ingress.pathWs`                  | Path for the websocket ingress                                                 | `/notifications/hub`                                    |
-| `ingress.pathType`                | Path type for the ingress                                                      | `Prefix`                                                |
-| `ingress.pathTypeWs`              | Path type for the ingress                                                      | `Exact`                                                 |
-| `ingress.tlsSecret`               | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                                                    |
-| `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                                                    |
+| Name                              | Description                                                                    | Value                |
+| --------------------------------- | ------------------------------------------------------------------------------ | -------------------- |
+| `websocket.enabled`               | Enable websocket notifications                                                 | `true`               |
+| `websocket.address`               | Websocket listen address                                                       | `0.0.0.0`            |
+| `websocket.port`                  | Websocket listen port                                                          | `3012`               |
+| `rocket.address`                  | Address to bind to                                                             | `0.0.0.0`            |
+| `rocket.port`                     | Rocket port                                                                    | `8080`               |
+| `rocket.workers`                  | Rocket number of workers                                                       | `10`                 |
+| `service.type`                    | Service type                                                                   | `ClusterIP`          |
+| `service.annotations`             | Additional annotations for the vaultwarden service                             | `{}`                 |
+| `service.labels`                  | Additional labels for the service                                              | `{}`                 |
+| `service.ipFamilyPolicy`          | IP family policy for the service                                               | `SingleStack`        |
+| `ingress.enabled`                 | Deploy an ingress resource.                                                    | `true`               |
+| `ingress.class`                   | Ingress resource class                                                         | `nginx`              |
+| `ingress.nginxIngressAnnotations` | Add nginx specific ingress annotations                                         | `true`               |
+| `ingress.additionalAnnotations`   | Additional annotations for the ingress resource.                               | `{}`                 |
+| `ingress.labels`                  | Additional labels for the ingress resource.                                    | `{}`                 |
+| `ingress.tls`                     | Enable TLS on the ingress resource.                                            | `true`               |
+| `ingress.hostname`                | Hostname for the ingress.                                                      | `warden.contoso.com` |
+| `ingress.additionalHostnames`     | Additional hostnames for the ingress.                                          | `[]`                 |
+| `ingress.path`                    | Default application path for the ingress                                       | `/`                  |
+| `ingress.pathWs`                  | Path for the websocket ingress                                                 | `/notifications/hub` |
+| `ingress.pathType`                | Path type for the ingress                                                      | `Prefix`             |
+| `ingress.pathTypeWs`              | Path type for the ingress                                                      | `Exact`              |
+| `ingress.tlsSecret`               | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                 |
+| `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                 |

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -118,6 +118,19 @@ ingress:
   allowList: "10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16"
 ```
 
+If you intend on making your ingress available via multiple hostnames, you can invoke the `ingress.additionalHostnames` as follows:
+
+```yaml
+ingress:
+  enabled: true
+  class: "nginx"
+  tlsSecret: vw-contoso-com-crt
+  hostname: vaultwarden.contoso.com
+  additionalHostnames:
+    - vw.contoso.com
+  allowList: "10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16"
+```
+
 ### AWS LB Controller
 
 When using AWS, the [AWS Load Balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/deploy/installation/) can be used together with [ACM](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/cert_discovery/).

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -414,30 +414,31 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `smtp.acceptInvalidCerts`         | Accept Invalid Certificates                                                                                                                         | `false`    |
 | `smtp.debug`                      | SMTP debugging                                                                                                                                      | `false`    |
 
-### Exposure settings 
+### Exposure settings
 
-| Name                              | Description                                                                    | Value                |
-| --------------------------------- | ------------------------------------------------------------------------------ | -------------------- |
-| `websocket.enabled`               | Enable websocket notifications                                                 | `true`               |
-| `websocket.address`               | Websocket listen address                                                       | `0.0.0.0`            |
-| `websocket.port`                  | Websocket listen port                                                          | `3012`               |
-| `rocket.address`                  | Address to bind to                                                             | `0.0.0.0`            |
-| `rocket.port`                     | Rocket port                                                                    | `8080`               |
-| `rocket.workers`                  | Rocket number of workers                                                       | `10`                 |
-| `service.type`                    | Service type                                                                   | `ClusterIP`          |
-| `service.annotations`             | Additional annotations for the vaultwarden service                             | `{}`                 |
-| `service.labels`                  | Additional labels for the service                                              | `{}`                 |
-| `service.ipFamilyPolicy`          | IP family policy for the service                                               | `SingleStack`        |
-| `ingress.enabled`                 | Deploy an ingress resource.                                                    | `false`              |
-| `ingress.class`                   | Ingress resource class                                                         | `nginx`              |
-| `ingress.nginxIngressAnnotations` | Add nginx specific ingress annotations                                         | `true`               |
-| `ingress.additionalAnnotations`   | Additional annotations for the ingress resource.                               | `{}`                 |
-| `ingress.labels`                  | Additional labels for the ingress resource.                                    | `{}`                 |
-| `ingress.tls`                     | Enable TLS on the ingress resource.                                            | `true`               |
-| `ingress.hostname`                | Hostname for the ingress.                                                      | `warden.contoso.com` |
-| `ingress.path`                    | Default application path for the ingress                                       | `/`                  |
-| `ingress.pathWs`                  | Path for the websocket ingress                                                 | `/notifications/hub` |
-| `ingress.pathType`                | Path type for the ingress                                                      | `Prefix`             |
-| `ingress.pathTypeWs`              | Path type for the ingress                                                      | `Exact`              |
-| `ingress.tlsSecret`               | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                 |
-| `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                 |
+| Name                              | Description                                                                    | Value                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| `websocket.enabled`               | Enable websocket notifications                                                 | `true`                                                  |
+| `websocket.address`               | Websocket listen address                                                       | `0.0.0.0`                                               |
+| `websocket.port`                  | Websocket listen port                                                          | `3012`                                                  |
+| `rocket.address`                  | Address to bind to                                                             | `0.0.0.0`                                               |
+| `rocket.port`                     | Rocket port                                                                    | `8080`                                                  |
+| `rocket.workers`                  | Rocket number of workers                                                       | `10`                                                    |
+| `service.type`                    | Service type                                                                   | `ClusterIP`                                             |
+| `service.annotations`             | Additional annotations for the vaultwarden service                             | `{}`                                                    |
+| `service.labels`                  | Additional labels for the service                                              | `{}`                                                    |
+| `service.ipFamilyPolicy`          | IP family policy for the service                                               | `SingleStack`                                           |
+| `ingress.enabled`                 | Deploy an ingress resource.                                                    | `true`                                                  |
+| `ingress.class`                   | Ingress resource class                                                         | `nginx`                                                 |
+| `ingress.nginxIngressAnnotations` | Add nginx specific ingress annotations                                         | `true`                                                  |
+| `ingress.additionalAnnotations`   | Additional annotations for the ingress resource.                               | `{}`                                                    |
+| `ingress.labels`                  | Additional labels for the ingress resource.                                    | `{}`                                                    |
+| `ingress.tls`                     | Enable TLS on the ingress resource.                                            | `true`                                                  |
+| `ingress.hostname`                | Hostname for the ingress.                                                      | `warden.contoso.com`                                    |
+| `ingress.additionalHostnames`     | Additional hostnames for the ingress.                                          | `["prod-warden.contoso.com","vaultwarden.contoso.com"]` |
+| `ingress.path`                    | Default application path for the ingress                                       | `/`                                                     |
+| `ingress.pathWs`                  | Path for the websocket ingress                                                 | `/notifications/hub`                                    |
+| `ingress.pathType`                | Path type for the ingress                                                      | `Prefix`                                                |
+| `ingress.pathTypeWs`              | Path type for the ingress                                                      | `Exact`                                                 |
+| `ingress.tlsSecret`               | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                                                    |
+| `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                                                    |

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -428,7 +428,7 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `service.annotations`             | Additional annotations for the vaultwarden service                             | `{}`                 |
 | `service.labels`                  | Additional labels for the service                                              | `{}`                 |
 | `service.ipFamilyPolicy`          | IP family policy for the service                                               | `SingleStack`        |
-| `ingress.enabled`                 | Deploy an ingress resource.                                                    | `true`               |
+| `ingress.enabled`                 | Deploy an ingress resource.                                                    | `false`              |
 | `ingress.class`                   | Ingress resource class                                                         | `nginx`              |
 | `ingress.nginxIngressAnnotations` | Add nginx specific ingress annotations                                         | `true`               |
 | `ingress.additionalAnnotations`   | Additional annotations for the ingress resource.                               | `{}`                 |

--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -1,4 +1,6 @@
 {{- $ingress := .Values.ingress -}}
+{{- $websocket := .Values.websocket -}}
+{{- $fullname := .Release.fullname -}}
 {{- if $ingress.enabled }}
 {{- $newAPIversion := .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 {{- if $newAPIversion }}
@@ -49,9 +51,33 @@ spec:
   tls:
     - hosts:
         - {{ $ingress.hostname | quote }}
+        {{- range $ingress.additionalHostnames }}
+        - {{ . | quote }}
+        {{- end }}
       secretName: {{ $ingress.tlsSecret }}
   {{- end }}
   rules:
+    {{- range $ingress.additionalHostnames }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+        - path: {{ $ingress.path }}
+          pathType: {{ $ingress.pathType }}
+          backend:
+            service:
+              name: {{ include "vaultwarden.fullname" $ }}
+              port:
+                name: "http"
+        {{- if $websocket.enabled }}
+        - path: {{ $ingress.pathWs }}
+          pathType: {{ $ingress.pathTypeWs }}
+          backend:
+            service:
+              name: {{ include "vaultwarden.fullname" $ }}
+              port:
+                name: "websocket"
+        {{- end }}
+    {{- end }}
     - host: {{ $ingress.hostname | quote }}
       http:
         paths:
@@ -62,7 +88,7 @@ spec:
               name: {{ include "vaultwarden.fullname" . }}
               port:
                 name: "http"
-        {{- if .Values.websocket.enabled }}
+        {{- if $websocket.enabled }}
         - path: {{ $ingress.pathWs }}
           pathType: {{ $ingress.pathTypeWs }}
           backend:

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -645,9 +645,7 @@ ingress:
   hostname: "warden.contoso.com"
   ## @param ingress.additionalHostnames Additional hostnames for the ingress.
   ##
-  additionalHostnames:
-    - "prod-warden.contoso.com"
-    - "vaultwarden.contoso.com"
+  additionalHostnames: []
   ## @param ingress.path Default application path for the ingress
   ##
   path: "/"

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -622,7 +622,7 @@ service:
 ingress:
   ## @param ingress.enabled Deploy an ingress resource.
   ##
-  enabled: true
+  enabled: false
   ## @param ingress.class Ingress resource class
   ## The Ingress class to use, e. g. "nginx" for a nginx ingress controller or "alb" for a AWS LB controller.
   #

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -622,7 +622,7 @@ service:
 ingress:
   ## @param ingress.enabled Deploy an ingress resource.
   ##
-  enabled: false
+  enabled: true
   ## @param ingress.class Ingress resource class
   ## The Ingress class to use, e. g. "nginx" for a nginx ingress controller or "alb" for a AWS LB controller.
   #
@@ -643,6 +643,11 @@ ingress:
   ## @param ingress.hostname Hostname for the ingress.
   ##
   hostname: "warden.contoso.com"
+  ## @param ingress.additionalHostnames Additional hostnames for the ingress.
+  ##
+  additionalHostnames:
+    - "prod-warden.contoso.com"
+    - "vaultwarden.contoso.com"
   ## @param ingress.path Default application path for the ingress
   ##
   path: "/"

--- a/generate-readme.sh
+++ b/generate-readme.sh
@@ -7,4 +7,4 @@ fi
 docker build -t readme-gen readme-generator-for-helm/
 
 # Run the tool and mount the current project directory.
-docker run --rm -v $(pwd):/mnt -w /mnt readme-gen readme-generator -v charts/vaultwarden/values.yaml -r charts/vaultwarden/README.md 
+docker run --rm --privileged -v $(pwd):/mnt -w /mnt readme-gen readme-generator -v charts/vaultwarden/values.yaml -r charts/vaultwarden/README.md 


### PR DESCRIPTION
This pull request allows users to easily create ingress rules to allow their Vaultwarden instance to use multiple FQDNs.

Key changes:
 - Updated documentation using the provided `generate-readme.sh` (btw, thank you for that!)
 - In the Ingress template, add two variables for abstraction of the global scope:
   - `$websocket`, which aliases back to `.Values.websocket`
   - `$fullname`, which aliases back to `.Release.fullname`
- Implementation of a range around `.Values.ingress.additionalHostnames` to create:
  - Ingress host records
  - Ingress rule sets
- On the `generate-readme.sh` script, add a flag to use a container in privileged mode, as Podman requires that for accessing the local filesystem using the volume mount method provided.