### PR TITLE
Do not udpate forbidden fields for statefulset

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.22.1
+version: 0.23.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.23.0
+version: 0.22.2
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/_pvcSpec.tpl
+++ b/charts/vaultwarden/templates/_pvcSpec.tpl
@@ -5,7 +5,9 @@ volumeClaimTemplates:
   - metadata:
       name: {{ .name }}
       labels:
-        {{- include "vaultwarden.labels" $ | nindent 10 }}
+        app.kubernetes.io/component: vaultwarden
+        app.kubernetes.io/name: {{ include "vaultwarden.fullname" . }}
+        app.kubernetes.io/instance: {{ include "vaultwarden.fullname" . }}
       annotations:
         meta.helm.sh/release-name: {{ $.Release.Name | quote }}
         meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}
@@ -26,7 +28,9 @@ volumeClaimTemplates:
   - metadata:
       name: {{ .name }}
       labels:
-        {{- include "vaultwarden.labels" $ | nindent 10 }}
+        app.kubernetes.io/component: vaultwarden
+        app.kubernetes.io/name: {{ include "vaultwarden.fullname" . }}
+        app.kubernetes.io/instance: {{ include "vaultwarden.fullname" . }}
       annotations:
         meta.helm.sh/release-name: {{ $.Release.Name | quote }}
         meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}


### PR DESCRIPTION
Every time I upgrade this helm chart I got this error
```
Error: UPGRADE FAILED: cannot patch "vaultwarden" with kind StatefulSet: StatefulSet.apps "vaultwarden" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```

Lets not put all the labels from helper, because they contain also chart version which changes on every upgrade
```
    volumeClaimTemplates:                                                                                            
      - metadata:                                         
          name: vaultwarden-data                          
          labels:                                         
-             helm.sh/chart: vaultwarden-0.20.0
+             helm.sh/chart: vaultwarden-0.22.1           
              app.kubernetes.io/name: vaultwarden         
              app.kubernetes.io/instance: vaultwarden
-             app.kubernetes.io/version: "1.30.1"      
+             app.kubernetes.io/version: "1.30.3"
              app.kubernetes.io/managed-by: Helm
```

Fixes: https://github.com/guerzon/vaultwarden/issues/58