### PR TITLE
fix _pvcSpec fullName

### DIFF
--- a/charts/vaultwarden/templates/_pvcSpec.tpl
+++ b/charts/vaultwarden/templates/_pvcSpec.tpl
@@ -1,4 +1,5 @@
 {{- define "vaultwarden.pvcSpec" }}
+{{- $fullName := include "vaultwarden.fullname" . -}}
 {{- if (or .Values.data .Values.attachments) -}}
 volumeClaimTemplates:
   {{- with .Values.data }}
@@ -6,8 +7,8 @@ volumeClaimTemplates:
       name: {{ .name }}
       labels:
         app.kubernetes.io/component: vaultwarden
-        app.kubernetes.io/name: {{ include "vaultwarden.fullname" . }}
-        app.kubernetes.io/instance: {{ include "vaultwarden.fullname" . }}
+        app.kubernetes.io/name: {{ $fullName }}
+        app.kubernetes.io/instance: {{ $fullName }}
       annotations:
         meta.helm.sh/release-name: {{ $.Release.Name | quote }}
         meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}


### PR DESCRIPTION
The _pvcSpec does not work for me in the current state. The values are not accessible and I get an error like this:

`Error: UPGRADE FAILED: template: vaultwarden/templates/statefulset.yaml:47:6: executing "vaultwarden/templates/statefulset.yaml" at <include "vaultwarden.pvcSpec" .>: error calling include: template: vaultwarden/templates/_pvcSpec.tpl:9:35: executing "vaultwarden.pvcSpec" at <include "vaultwarden.fullname" .>: error calling include: template: vaultwarden/templates/_helpers.tpl:15:14: executing "vaultwarden.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride`

This PR fixes it by defining a variable outside the .Values.data scope.