### PR TITLE
Fix app.kubernetes.io labels to use $ instead of . in vaultwarden chart

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.22.2
+version: 0.22.3
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/_pvcSpec.tpl
+++ b/charts/vaultwarden/templates/_pvcSpec.tpl
@@ -6,8 +6,8 @@ volumeClaimTemplates:
       name: {{ .name }}
       labels:
         app.kubernetes.io/component: vaultwarden
-        app.kubernetes.io/name: {{ include "vaultwarden.fullname" . }}
-        app.kubernetes.io/instance: {{ include "vaultwarden.fullname" . }}
+        app.kubernetes.io/name: {{ include "vaultwarden.fullname" $ }}
+        app.kubernetes.io/instance: {{ include "vaultwarden.fullname" $ }}
       annotations:
         meta.helm.sh/release-name: {{ $.Release.Name | quote }}
         meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}
@@ -29,8 +29,8 @@ volumeClaimTemplates:
       name: {{ .name }}
       labels:
         app.kubernetes.io/component: vaultwarden
-        app.kubernetes.io/name: {{ include "vaultwarden.fullname" . }}
-        app.kubernetes.io/instance: {{ include "vaultwarden.fullname" . }}
+        app.kubernetes.io/name: {{ include "vaultwarden.fullname" $ }}
+        app.kubernetes.io/instance: {{ include "vaultwarden.fullname" $ }}
       annotations:
         meta.helm.sh/release-name: {{ $.Release.Name | quote }}
         meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}


### PR DESCRIPTION
This commit changes the way the `app.kubernetes.io/name` and `app.kubernetes.io/instance` labels are generated in the vaultwarden Helm chart. Previously, the `.Values` object was used directly within the template expression, which is not allowed by Helm. This change updates the expression to use the `$` symbol, which correctly references the current values context.