### PR TITLE
fix: configmap flow control

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.22.3
+version: 0.22.4
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -99,10 +99,10 @@ data:
   REQUIRE_DEVICE_EMAIL: {{ .Values.requireDeviceEmail | quote }}
   TRASH_AUTO_DELETE_DAYS: {{ .Values.trashAutoDeleteDays | quote }}
   {{- with .Values.timeZone }}
-  TZ: {{ .Values.timeZone | quote }}
+  TZ: {{ . | quote }}
+  {{- end }}
   {{- with .Values.hibpApiKey }}
   HIBP_API_KEY: {{ . | quote }}
-  {{- end }}
   {{- end }}
   {{- with .Values.orgAttachmentLimit }}
   ORG_ATTACHMENT_LIMIT: {{ . | quote }}


### PR DESCRIPTION
This pull request repairs broken behavior in the template that prevented HIBP tokens from being injected into the environment config map when a time zone was not declated.

Key changes:
- Change flow control for the `TZ` variable to include it when being provided as `.Values.timeZone`, and end the flow control as soon as the variable has been injected into the ConfigMap.
- Remove the errant flow control end from beneath the `HIBP_API_KEY` variable declaration.
- Increment chart for bug fix, from `0.22.3` to `0.22.4`
