### PR TITLE
feat(pushNotifications): add configuration option for data region

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.22.4
+version: 0.22.5
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -62,6 +62,12 @@ data:
   PUSH_ENABLED: "true"
   PUSH_INSTALLATION_ID: {{ .Values.pushNotifications.installationId | quote }}
   PUSH_INSTALLATION_KEY: {{ .Values.pushNotifications.installationKey | quote }}
+  {{- with .Values.pushNotifications.relayUri }}
+  PUSH_RELAY_URI: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.pushNotifications.identityUri }}
+  PUSH_IDENTITY_URI: {{ . | quote }}
+  {{- end }}
   {{- end }}
   {{- if and .Values.yubico.clientId .Values.yubico.secretKey }}
   YUBICO_CLIENT_ID: {{ .Values.yubico.clientId | quote }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -282,6 +282,8 @@ database:
 pushNotifications: {}
   # installationId: ""
   # installationKey: ""
+  # relayUri: "https://push.bitwarden.com"
+  # identityUri: "https://identity.bitwarden.com"
 
 ## @section Scheduled jobs
 ##


### PR DESCRIPTION
Added `PUSH_RELAY_URI` & `PUSH_IDENTITY_URI`.
This is required when using the EU data region for the push notifications.

Both values are optional, when not set it defaults to the US servers.
Alternatively we could change this to one configuration option called `dataRegion`, which could be set to either `us` or `eu`, but specifying the URI's directly gives maximum flexibilitiy.