### PR TITLE
Fix for external DNS resolution

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.22.6
+version: 0.22.7
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -1,8 +1,8 @@
 {{- define "vaultwarden.podSpec" }}
+{{- with .Values.dnsConfig }}
 dnsConfig:
-  options:
-    - name: ndots
-      value: "1"
+{{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with .Values.nodeSelector }}
 nodeSelector:
 {{- toYaml . | nindent 2 }}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -1,4 +1,8 @@
 {{- define "vaultwarden.podSpec" }}
+dnsConfig:
+  options:
+    - name: ndots
+      value: "1"
 {{- with .Values.nodeSelector }}
 nodeSelector:
 {{- toYaml . | nindent 2 }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -104,6 +104,10 @@ securityContext: {}
   #   drop:
   #     - ALL
 
+## @param dnsConfig Pod DNS options
+## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+dnsConfig: {}
+
 
 ## @section Reliability configuration
 ##


### PR DESCRIPTION
Certain setups seem to have trouble with the default ndots:5 dns config. Setting this value to 1 should resolve this.

For an example, this breaks DNS resolution of the identity.bitwarden.com domain, because it appends the Kubernetes search domain to it.