### PR TITLE
#27 - support running multiple replicas for HA

### DIFF
--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/component: vaultwarden

--- a/charts/vaultwarden/templates/statefulset.yaml
+++ b/charts/vaultwarden/templates/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   serviceName: vaultwarden
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/component: vaultwarden

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -676,3 +676,7 @@ ingress:
   ##   - Add support for using cert-manager.
   ##   - Support for multiple TLS hostnames.
   ##
+
+## @section High availability settings
+## @param replicaCount control how many replicas are deployed in the statefulset or deployment
+replicaCount: 1


### PR DESCRIPTION
This PR adds `replicaCount` to values, with default 1, so that users of the chart can run the chart in a HA setup with multiple replicas.