### PR TITLE
podSpec: use the $ operator while generating secretKeyRefs

### DIFF
--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -40,7 +40,7 @@ containers:
       - name: {{ .key }}
         valueFrom:
           secretKeyRef:
-            name: {{ include "vaultwarden.fullname" . }}
+            name: {{ include "vaultwarden.fullname" $ }}
             key: {{ .key }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
Inside of range, `.` refers to the current item during iteration, whereas `$` refers to the global scope.

test.yaml:

```
image:
  extraSecrets:
    - key: SSO_CLIENT_ID
      value: test-value
```

before:

```
$ helm template release ./charts/vaultwarden -f test.yaml 
Error: template: vaultwarden/templates/statefulset.yaml:43:10: executing "vaultwarden/templates/statefulset.yaml" at <include "vaultwarden.podSpec" .>: error calling include: template: vaultwarden/templates/_podSpec.tpl:43:21: executing "vaultwarden.podSpec" at <include "vaultwarden.fullname" .>: error calling include: template: vaultwarden/templates/_helpers.tpl:15:14: executing "vaultwarden.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride

Use --debug flag to render out invalid YAML
```

after:

```
$ helm template release ./charts/vaultwarden -f test.yaml 
---
# Source: vaultwarden/templates/rbac.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: vaultwarden-svc
  namespace: default
  labels:
    app.kubernetes.io/component: vaultwarden
[snip]
          env:
            - name: SSO_CLIENT_ID
              valueFrom:
                secretKeyRef:
                  name: release-vaultwarden
                  key: SSO_CLIENT_ID
[snip]
```