### PR TITLE
service: use selectorLabels helper

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.24.3
+version: 0.24.4
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/service.yaml
+++ b/charts/vaultwarden/templates/service.yaml
@@ -17,6 +17,7 @@ spec:
   type: {{ .Values.service.type | quote }}
   selector:
     app.kubernetes.io/component: vaultwarden
+    {{- include "vaultwarden.selectorLabels" . | nindent 4 }}
   ports:
     - name: "http"
       port: 80


### PR DESCRIPTION
fixes #93 

before:

```
$ helm template release ./vaultwarden
[snip]
apiVersion: v1
kind: Service
metadata:
  name: release-vaultwarden
  namespace: default
  labels:
    app.kubernetes.io/component: vaultwarden
    helm.sh/chart: vaultwarden-0.23.0
    app.kubernetes.io/name: vaultwarden
    app.kubernetes.io/instance: release
    app.kubernetes.io/version: "1.30.3"
    app.kubernetes.io/managed-by: Helm
spec:
  type: "ClusterIP"
  selector:
    app.kubernetes.io/component: vaultwarden
  ports:
    - name: "http"
      port: 80
      protocol: TCP
      targetPort: 8080
    - name: "websocket"
      port: 3012
      protocol: TCP
      targetPort: 3012
  ipFamilyPolicy: SingleStack
[snip]
```

after:

```
$ helm template release ./vaultwarden
[snip]
kind: Service
metadata:
  name: release-vaultwarden
  namespace: default
  labels:
    app.kubernetes.io/component: vaultwarden
    helm.sh/chart: vaultwarden-0.23.0
    app.kubernetes.io/name: vaultwarden
    app.kubernetes.io/instance: release
    app.kubernetes.io/version: "1.30.3"
    app.kubernetes.io/managed-by: Helm
spec:
  type: "ClusterIP"
  selector:
    app.kubernetes.io/name: vaultwarden
    app.kubernetes.io/instance: release
[snip]
```