### PR TITLE
Websocket via legacy custom implementation disabled by default

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.23.0
+version: 0.23.1
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -432,29 +432,30 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 
 ### Exposure settings
 
-| Name                              | Description                                                                    | Value                |
-| --------------------------------- | ------------------------------------------------------------------------------ | -------------------- |
-| `websocket.enabled`               | Enable websocket notifications                                                 | `true`               |
-| `websocket.address`               | Websocket listen address                                                       | `0.0.0.0`            |
-| `websocket.port`                  | Websocket listen port                                                          | `3012`               |
-| `rocket.address`                  | Address to bind to                                                             | `0.0.0.0`            |
-| `rocket.port`                     | Rocket port                                                                    | `8080`               |
-| `rocket.workers`                  | Rocket number of workers                                                       | `10`                 |
-| `service.type`                    | Service type                                                                   | `ClusterIP`          |
-| `service.annotations`             | Additional annotations for the vaultwarden service                             | `{}`                 |
-| `service.labels`                  | Additional labels for the service                                              | `{}`                 |
-| `service.ipFamilyPolicy`          | IP family policy for the service                                               | `SingleStack`        |
-| `ingress.enabled`                 | Deploy an ingress resource.                                                    | `false`              |
-| `ingress.class`                   | Ingress resource class                                                         | `nginx`              |
-| `ingress.nginxIngressAnnotations` | Add nginx specific ingress annotations                                         | `true`               |
-| `ingress.additionalAnnotations`   | Additional annotations for the ingress resource.                               | `{}`                 |
-| `ingress.labels`                  | Additional labels for the ingress resource.                                    | `{}`                 |
-| `ingress.tls`                     | Enable TLS on the ingress resource.                                            | `true`               |
-| `ingress.hostname`                | Hostname for the ingress.                                                      | `warden.contoso.com` |
-| `ingress.additionalHostnames`     | Additional hostnames for the ingress.                                          | `[]`                 |
-| `ingress.path`                    | Default application path for the ingress                                       | `/`                  |
-| `ingress.pathWs`                  | Path for the websocket ingress                                                 | `/notifications/hub` |
-| `ingress.pathType`                | Path type for the ingress                                                      | `Prefix`             |
-| `ingress.pathTypeWs`              | Path type for the ingress                                                      | `Exact`              |
-| `ingress.tlsSecret`               | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                 |
-| `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                 |
+| Name                              | Description                                                                    | Value                 |
+|-----------------------------------|--------------------------------------------------------------------------------|-----------------------|
+| `websocket.legacyEnabled`         | Enable websocket notifications via the legacy custom websocket implementation  | `false`               |
+| `websocket.address`               | Websocket listen address                                                       | `0.0.0.0`             |
+| `websocket.port`                  | Websocket listen port                                                          | `3012`                |
+| `rocket.address`                  | Address to bind to                                                             | `0.0.0.0`             |
+| `rocket.port`                     | Rocket port                                                                    | `8080`                |
+| `rocket.workers`                  | Rocket number of workers                                                       | `10`                  |
+| `service.type`                    | Service type                                                                   | `ClusterIP`           |
+| `service.annotations`             | Additional annotations for the vaultwarden service                             | `{}`                  |
+| `service.labels`                  | Additional labels for the service                                              | `{}`                  |
+| `service.ipFamilyPolicy`          | IP family policy for the service                                               | `SingleStack`         |
+| `ingress.enabled`                 | Deploy an ingress resource.                                                    | `false`               |
+| `ingress.class`                   | Ingress resource class                                                         | `nginx`               |
+| `ingress.nginxIngressAnnotations` | Add nginx specific ingress annotations                                         | `true`                |
+| `ingress.additionalAnnotations`   | Additional annotations for the ingress resource.                               | `{}`                  |
+| `ingress.labels`                  | Additional labels for the ingress resource.                                    | `{}`                  |
+| `ingress.tls`                     | Enable TLS on the ingress resource.                                            | `true`                |
+| `ingress.hostname`                | Hostname for the ingress.                                                      | `warden.contoso.com`  |
+| `ingress.additionalHostnames`     | Additional hostnames for the ingress.                                          | `[]`                  |
+| `ingress.path`                    | Default application path for the ingress                                       | `/`                   |
+| `ingress.pathWs`                  | Path for the websocket ingress                                                 | `/notifications/hub`  |
+| `ingress.pathType`                | Path type for the ingress                                                      | `Prefix`              |
+| `ingress.pathTypeWs`              | Path type for the ingress                                                      | `Exact`               |
+| `ingress.tlsSecret`               | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                  |
+| `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                  |
+| `ingress.connectionProxyHeader`   | Connection proxy header.                                                       | `$connection_upgrade` |

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
   SMTP_ACCEPT_INVALID_HOSTNAMES: {{ .Values.smtp.acceptInvalidHostnames | quote }}
   SMTP_ACCEPT_INVALID_CERTS: {{ .Values.smtp.acceptInvalidCerts | quote }}
   {{- end }}
-  {{- if .Values.websocket.enabled }}
+  {{- if .Values.websocket.legacyEnabled }}
   WEBSOCKET_ENABLED: "true"
   WEBSOCKET_ADDRESS: {{ .Values.websocket.address | quote }}
   WEBSOCKET_PORT: {{ .Values.websocket.port | quote }}

--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -29,7 +29,7 @@ metadata:
     {{- if $ingress.nginxIngressAnnotations }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "Request-Id: $req_id";
-    nginx.ingress.kubernetes.io/connection-proxy-header: "keep-alive"
+    nginx.ingress.kubernetes.io/connection-proxy-header: {{ $ingress.connectionProxyHeader }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -68,7 +68,7 @@ spec:
               name: {{ include "vaultwarden.fullname" $ }}
               port:
                 name: "http"
-        {{- if $websocket.enabled }}
+        {{- if $websocket.legacyEnabled }}
         - path: {{ $ingress.pathWs }}
           pathType: {{ $ingress.pathTypeWs }}
           backend:
@@ -88,7 +88,7 @@ spec:
               name: {{ include "vaultwarden.fullname" . }}
               port:
                 name: "http"
-        {{- if $websocket.enabled }}
+        {{- if $websocket.legacyEnabled }}
         - path: {{ $ingress.pathWs }}
           pathType: {{ $ingress.pathTypeWs }}
           backend:

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -604,12 +604,12 @@ smtp:
 ## @section Exposure settings
 ##
 
-## @param websocket.enabled Enable websocket notifications
+## @param websocket.legacyEnabled Enable websocket notifications via the legacy custom websocket implementation
 ## @param websocket.address Websocket listen address
 ## @param websocket.port Websocket listen port
 ##
 websocket:
-  enabled: true
+  legacyEnabled: false
   address: "0.0.0.0"
   port: 3012
 
@@ -690,3 +690,5 @@ ingress:
   ##   - Add support for using cert-manager.
   ##   - Support for multiple TLS hostnames.
   ##
+  ## @param ingress.connectionProxyHeader Connection proxy header.
+  connectionProxyHeader: "$connection_upgrade"


### PR DESCRIPTION
Fixes https://github.com/guerzon/vaultwarden/issues/87

Moreover, using `$connection_upgrade` as the recommended Proxy Header for Connection. I checked Ingress config, and it already has the mapping for both headers-values. So, if people want to use the `keep-alive` they can still set that value under `ingress`.

Websockets working via Rocket using the values provided by this PR. Proofs:

Ingress Controller Logs:
![image](https://github.com/guerzon/vaultwarden/assets/8237539/2393970e-45a6-4ada-9851-9f505df67e4d)

Web browser simultaneous session (creating an item in a private tab, immediately shows the item in the other browser):
![image](https://github.com/guerzon/vaultwarden/assets/8237539/2f4eb506-e5e9-469d-b1c7-d7c42bdfa057)


