### PR TITLE
chore: bump to 1.31.0

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.23.1
+version: 0.24.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 sources:
   - https://github.com/guerzon/vaultwarden
   - https://github.com/dani-garcia/vaultwarden
-appVersion: 1.30.3
+appVersion: 1.31.0
 maintainers:
   - name: guerzon
     email: guerzon@proton.me

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -260,7 +260,7 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | ----------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`        | Vaultwarden image registry                                                                | `docker.io`          |
 | `image.repository`      | Vaultwarden image repository                                                              | `vaultwarden/server` |
-| `image.tag`             | Vaultwarden image tag                                                                     | `1.30.3-alpine`      |
+| `image.tag`             | Vaultwarden image tag                                                                     | `1.31.0-alpine`      |
 | `image.pullPolicy`      | Vaultwarden image pull policy                                                             | `IfNotPresent`       |
 | `image.pullSecrets`     | Specify docker-registry secret names                                                      | `[]`                 |
 | `image.extraSecrets`    | Vaultwarden image extra secrets                                                           | `[]`                 |
@@ -434,9 +434,6 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 
 | Name                              | Description                                                                    | Value                |
 | --------------------------------- | ------------------------------------------------------------------------------ | -------------------- |
-| `websocket.enabled`               | Enable websocket notifications                                                 | `true`               |
-| `websocket.address`               | Websocket listen address                                                       | `0.0.0.0`            |
-| `websocket.port`                  | Websocket listen port                                                          | `3012`               |
 | `rocket.address`                  | Address to bind to                                                             | `0.0.0.0`            |
 | `rocket.port`                     | Rocket port                                                                    | `8080`               |
 | `rocket.workers`                  | Rocket number of workers                                                       | `10`                 |
@@ -453,8 +450,6 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `ingress.hostname`                | Hostname for the ingress.                                                      | `warden.contoso.com` |
 | `ingress.additionalHostnames`     | Additional hostnames for the ingress.                                          | `[]`                 |
 | `ingress.path`                    | Default application path for the ingress                                       | `/`                  |
-| `ingress.pathWs`                  | Path for the websocket ingress                                                 | `/notifications/hub` |
 | `ingress.pathType`                | Path type for the ingress                                                      | `Prefix`             |
-| `ingress.pathTypeWs`              | Path type for the ingress                                                      | `Exact`              |
 | `ingress.tlsSecret`               | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                 |
 | `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                 |

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -87,9 +87,6 @@ containers:
       - containerPort: 8080
         name: http
         protocol: TCP
-      - containerPort: {{ .Values.websocket.port }}
-        name: websocket
-        protocol: TCP
     {{- if or (.Values.data) (.Values.attachments) }}
     volumeMounts:
       {{- with .Values.data }}

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -25,11 +25,6 @@ data:
   SMTP_ACCEPT_INVALID_HOSTNAMES: {{ .Values.smtp.acceptInvalidHostnames | quote }}
   SMTP_ACCEPT_INVALID_CERTS: {{ .Values.smtp.acceptInvalidCerts | quote }}
   {{- end }}
-  {{- if .Values.websocket.enabled }}
-  WEBSOCKET_ENABLED: "true"
-  WEBSOCKET_ADDRESS: {{ .Values.websocket.address | quote }}
-  WEBSOCKET_PORT: {{ .Values.websocket.port | quote }}
-  {{- end }}
   {{- if .Values.data }}
   DATA_FOLDER: {{ default "/data" .Values.data.path | quote }}
   {{- end }}

--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -1,5 +1,4 @@
 {{- $ingress := .Values.ingress -}}
-{{- $websocket := .Values.websocket -}}
 {{- $fullname := .Release.fullname -}}
 {{- if $ingress.enabled }}
 {{- $newAPIversion := .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
@@ -68,15 +67,6 @@ spec:
               name: {{ include "vaultwarden.fullname" $ }}
               port:
                 name: "http"
-        {{- if $websocket.enabled }}
-        - path: {{ $ingress.pathWs }}
-          pathType: {{ $ingress.pathTypeWs }}
-          backend:
-            service:
-              name: {{ include "vaultwarden.fullname" $ }}
-              port:
-                name: "websocket"
-        {{- end }}
     {{- end }}
     - host: {{ $ingress.hostname | quote }}
       http:
@@ -88,13 +78,4 @@ spec:
               name: {{ include "vaultwarden.fullname" . }}
               port:
                 name: "http"
-        {{- if $websocket.enabled }}
-        - path: {{ $ingress.pathWs }}
-          pathType: {{ $ingress.pathTypeWs }}
-          backend:
-            service:
-              name: {{ include "vaultwarden.fullname" . }}
-              port:
-                name: "websocket"
-        {{- end }}
 {{- end }}

--- a/charts/vaultwarden/templates/service.yaml
+++ b/charts/vaultwarden/templates/service.yaml
@@ -22,12 +22,6 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 8080
-    {{- if .Values.websocket.enabled }}
-    - name: "websocket"
-      port: 3012
-      protocol: TCP
-      targetPort: {{ .Values.websocket.port }}
-    {{- end }}
 {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
 {{- end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -604,15 +604,6 @@ smtp:
 ## @section Exposure settings
 ##
 
-## @param websocket.enabled Enable websocket notifications
-## @param websocket.address Websocket listen address
-## @param websocket.port Websocket listen port
-##
-websocket:
-  enabled: true
-  address: "0.0.0.0"
-  port: 3012
-
 ## @param rocket.address Address to bind to
 ## @param rocket.port Rocket port
 ## @param rocket.workers Rocket number of workers
@@ -669,17 +660,10 @@ ingress:
   ## @param ingress.path Default application path for the ingress
   ##
   path: "/"
-  ## @param ingress.pathWs Path for the websocket ingress
-  ##
-  pathWs: "/notifications/hub"
   ## @param ingress.pathType Path type for the ingress
   ## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
   ##
   pathType: "Prefix"
-  ## @param ingress.pathTypeWs Path type for the ingress
-  ## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
-  ##
-  pathTypeWs: "Exact"
   ## @param ingress.tlsSecret Kubernetes secret containing the SSL certificate when using the "nginx" class.
   ##
   tlsSecret: ""

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -13,7 +13,7 @@ image:
   ## @param image.tag Vaultwarden image tag
   ## Ref: https://hub.docker.com/r/vaultwarden/server/tags
   ##
-  tag: "1.30.3-alpine"
+  tag: "1.31.0-alpine"
   ## @param image.pullPolicy Vaultwarden image pull policy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
fixes #102:

- removes everything that is related to WebSockets
- bump the vaultwarden version to 1.31.0
- bump the chart minor version