### PR TITLE
feat: Replace nginx snippet annotation with custom header annotation

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.24.5
+version: 0.25.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.24.0
+version: 0.24.1
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.24.1
+version: 0.25.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -1,6 +1,21 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: custom-headers-configmap
+data:
+  Request-Id: $req_id
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-configuration
+  namespace: {{ .Release.Namespace }}
+data:
+  global-allowed-response-headers: Referrer-Policy,Strict-Transport-Security,X-Content-Type-Options,X-Frame-Options,Content-Security-Policy,Request-Id
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: {{ include "vaultwarden.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -8,14 +8,6 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-configuration
-  namespace: {{ .Release.Namespace }}
-data:
-  global-allowed-response-headers: Referrer-Policy,Strict-Transport-Security,X-Content-Type-Options,X-Frame-Options,Content-Security-Policy,Request-Id
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: {{ include "vaultwarden.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: customer-headers-configmap
+data:
+  Request-Id: $req_id
+---
 {{- $ingress := .Values.ingress -}}
 {{- $fullname := .Release.fullname -}}
 {{- if $ingress.enabled }}
@@ -26,8 +33,7 @@ metadata:
     {{- toYaml $ingress.additionalAnnotations | nindent 4 }}
     {{- end }}
     {{- if $ingress.nginxIngressAnnotations }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers "Request-Id: $req_id";
+    nginx.ingress.kubernetes.io/custom-headers: custom-headers-configmap
     nginx.ingress.kubernetes.io/connection-proxy-header: "keep-alive"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -33,7 +33,7 @@ metadata:
     {{- toYaml $ingress.additionalAnnotations | nindent 4 }}
     {{- end }}
     {{- if $ingress.nginxIngressAnnotations }}
-    nginx.ingress.kubernetes.io/custom-headers: custom-headers-configmap
+    nginx.ingress.kubernetes.io/custom-headers: {{ $ingress.customHeadersConfigMap }}
     nginx.ingress.kubernetes.io/connection-proxy-header: "keep-alive"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: customer-headers-configmap
-data:
-  Request-Id: $req_id
----
 {{- $ingress := .Values.ingress -}}
 {{- $fullname := .Release.fullname -}}
 {{- if $ingress.enabled }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -101,13 +101,15 @@ serviceAccount:
 
 ## @param podSecurityContext Pod security options
 ##
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 1001
   # supplementalGroups:
   #   - 1001
 
 ## @param securityContext Default security options to run vault as read only container without privilege escalation
-securityContext: {}
+securityContext:
+  {}
   # allowPrivilegeEscalation: false
   # privileged: false
   # readOnlyRootFilesystem: true
@@ -121,7 +123,6 @@ securityContext: {}
 ## @param dnsConfig Pod DNS options
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
 dnsConfig: {}
-
 
 ## @section Reliability configuration
 ##
@@ -194,7 +195,8 @@ startupProbe:
 
 ## @param resources Resource configurations
 ##
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -208,7 +210,8 @@ resources: {}
 
 ## @param strategy Resource configurations
 ##
-strategy: {}
+strategy:
+  {}
   # type: RollingUpdate
   # rollingUpdate:
   #   maxSurge: 1
@@ -224,13 +227,13 @@ podDisruptionBudget:
   ## @param podDisruptionBudget.maxUnavailable Maximum number/percentage of pods that may be made unavailable
   maxUnavailable: null
 
-
 ## @section Persistent data configuration
 ##
 
 ## @param data Data directory configuration, refer to values.yaml for parameters.
 ##
-data: {}
+data:
+  {}
   # name: "vaultwarden-data"
   # size: "15Gi"
   # class: ""
@@ -240,7 +243,8 @@ data: {}
 ## @param attachments Attachments directory configuration, refer to values.yaml for parameters.
 ## By default, attachments/ is located inside the data directory.
 ##
-attachments: {}
+attachments:
+  {}
   # name: "vaultwarden-files"
   # size: "100Gi"
   # class: ""
@@ -297,7 +301,8 @@ database:
 ## Supported since 1.29.0.
 ## Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
 ##
-pushNotifications: {}
+pushNotifications:
+  {}
   # installationId: ""
   # installationKey: ""
   # relayUri: "https://push.bitwarden.com"
@@ -423,7 +428,6 @@ emailChangeAllowed: "true"
 ##
 showPassHint: "false"
 
-
 ## @section Advanced settings
 ##
 
@@ -501,13 +505,11 @@ adminRateLimitMaxBurst: "3"
 ##
 timeZone: ""
 
-
 ## @section BETA Features
 ##
 
 ## @param orgGroupsEnabled Controls whether group support is enabled for organizations
 orgGroupsEnabled: "false"
-
 
 ## @section MFA/2FA settings
 ##
@@ -535,7 +537,6 @@ duo:
   ## @param duo.hostname Duo API hostname
   ##
   hostname: ""
-
 
 ## @section SMTP Configuration
 ##
@@ -600,7 +601,6 @@ smtp:
   ##
   debug: false
 
-
 ## @section Exposure settings
 ##
 
@@ -639,7 +639,7 @@ ingress:
   #
   class: "nginx"
   ## @param ingress.nginxIngressAnnotations Add nginx specific ingress annotations
-  ## This annotations are only makes sense for the kubernetes nginx ingress controller (https://kubernetes.github.io/ingress-nginx/)
+  ## These annotations only make sense for the kubernetes nginx ingress controller (https://kubernetes.github.io/ingress-nginx/)
   ##
   nginxIngressAnnotations: true
   ## @param ingress.additionalAnnotations Additional annotations for the ingress resource.
@@ -670,6 +670,10 @@ ingress:
   ## @param ingress.nginxAllowList Comma-separated list of IP addresses and subnets to allow.
   ##
   nginxAllowList: ""
+  ## @param ingress.customHeadersConfigMap ConfigMap containing custom headers to be added to the ingress.
+  ## Defaults to "custom-headers-configmap", which sets a Request-ID header.
+  ##
+  customHeadersConfigMap: "custom-headers-configmap"
   ## TODO:
   ##   - Add support for using cert-manager.
   ##   - Support for multiple TLS hostnames.


### PR DESCRIPTION
Our cluster does not allow snippet annotations by default and changing the configuration would be complicated.

But the snippet is not actually needed, since the same thing can be achieve using a config map and the custom-headers annotation.