### PR TITLE
Push Notifications existing secret

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.24.0
+version: 0.24.2
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -335,11 +335,17 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `database.connectionRetries` | Number of times to retry the database connection during startup, with 1 second delay between each retry, set to 0 to retry indefinitely. | `15`      |
 | `database.maxConnections`    | Define the size of the connection pool used for connecting to the database.                                                              | `10`      |
 
-### Push notifications
+### Push Notifications
 
-| Name                | Description                                                      | Value |
-| ------------------- | ---------------------------------------------------------------- | ----- |
-| `pushNotifications` | Enable mobile push notifications, see values.yaml for parameters | `{}`  |
+| Name                                                  | Description                                                                         | Value                            |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------- |
+| `pushNotifications.existingSecret`                    | Name of an existing secret containing the Bitwarden installation id and key         | `""`                             |
+| `pushNotifications.installationId.value`              | Bitwarden installation id string                                                    | `""`                             |
+| `pushNotifications.installationId.existingSecretKey`  | When using an existing secret, specify the key which contains the installation id.  | `""`                             |
+| `pushNotifications.installationKey.value`             | Bitwarden installation key string                                                   | `""`                             |
+| `pushNotifications.installationKey.existingSecretKey` | When using an existing secret, specify the key which contains the installation key. | `""`                             |
+| `pushNotifications.relayUri`                          | Change Bitwarden relay uri.                                                         | `https://push.bitwarden.com`     |
+| `pushNotifications.identityUri`                       | Change Bitwarden identity uri.                                                      | `https://identity.bitwarden.com` |
 
 ### Scheduled jobs
 

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -68,6 +68,20 @@ containers:
       - name: DISABLE_ADMIN_TOKEN
         value: "true"
       {{- end }}
+      {{- if or (.Values.pushNotifications.installationId.value) (.Values.pushNotifications.installationId.existingSecretKey )}}
+      - name: PUSH_INSTALLATION_ID
+        valueFrom:
+          secretKeyRef:
+            name: {{ default (include "vaultwarden.fullname" .) .Values.pushNotifications.existingSecret }}
+            key: {{ default "PUSH_INSTALLATION_ID" .Values.pushNotifications.installationId.existingSecretKey }}
+      {{- end }}
+      {{- if or (.Values.pushNotifications.installationKey.value) (.Values.pushNotifications.installationKey.existingSecretKey )}}
+      - name: PUSH_INSTALLATION_KEY
+        valueFrom:
+          secretKeyRef:
+            name: {{ default (include "vaultwarden.fullname" .) .Values.pushNotifications.existingSecret }}
+            key: {{ default "PUSH_INSTALLATION_KEY" .Values.pushNotifications.installationKey.existingSecretKey }}
+      {{- end }}
       {{- if ne "default" .Values.database.type }}
       - name: DATABASE_URL
         {{- if .Values.database.existingSecret }}

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -55,8 +55,6 @@ data:
   IP_HEADER: {{ .Values.ipHeader | quote }}
   {{- if .Values.pushNotifications }}
   PUSH_ENABLED: "true"
-  PUSH_INSTALLATION_ID: {{ .Values.pushNotifications.installationId | quote }}
-  PUSH_INSTALLATION_KEY: {{ .Values.pushNotifications.installationKey | quote }}
   {{- with .Values.pushNotifications.relayUri }}
   PUSH_RELAY_URI: {{ . | quote }}
   {{- end }}

--- a/charts/vaultwarden/templates/secrets.yaml
+++ b/charts/vaultwarden/templates/secrets.yaml
@@ -16,6 +16,10 @@ data:
   SMTP_PASSWORD: {{ .Values.smtp.password.value | b64enc | quote }}
   SMTP_USERNAME: {{ .Values.smtp.username.value | b64enc | quote }}
   {{- end }}
+  {{- if not ( .Values.pushNotifications.existingSecret ) }}
+  PUSH_INSTALLATION_ID: {{ .Values.pushNotifications.installationId.value | b64enc | quote }}
+  PUSH_INSTALLATION_KEY: {{ .Values.pushNotifications.installationKey.value | b64enc | quote }}
+  {{- end }}
   {{- if not ( .Values.adminToken.existingSecret ) }}
   ADMIN_TOKEN: {{ .Values.adminToken.value | b64enc | quote }}
   {{- end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -290,19 +290,15 @@ database:
   ##
   maxConnections: 10
 
-## @section Push notifications
+## @section Push Notifications
+## Supported since 1.29.0.
+## Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
 ##
 
-## @extra pushNotifications Enable mobile push notifications. Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
-## Supported since 1.29.0.
-## 
-##
 pushNotifications: 
   ## @param pushNotifications.existingSecret Name of an existing secret containing the Bitwarden installation id and key
   ##
   existingSecret: ""
-  ## @extra pushNotifications.installationId Installation Id for mobile push notifications
-  ##
   installationId: 
     ## @param pushNotifications.installationId.value Bitwarden installation id string
     ## Example: installationIdGoesHere
@@ -312,7 +308,6 @@ pushNotifications:
     ## Example: INSTALLATION_ID
     ## 
     existingSecretKey: ""
-  ## @extra pushNotifications.installationKey Installation Key for mobile push notifications
   installationKey:
     ## @param pushNotifications.installationKey.value Bitwarden installation key string
     ## Example: superSecretInstallationKey

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -293,15 +293,43 @@ database:
 ## @section Push notifications
 ##
 
-## @param pushNotifications Enable mobile push notifications, see values.yaml for parameters
+## @extra pushNotifications Enable mobile push notifications. Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
 ## Supported since 1.29.0.
-## Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
+## 
 ##
-pushNotifications: {}
-  # installationId: ""
-  # installationKey: ""
-  # relayUri: "https://push.bitwarden.com"
-  # identityUri: "https://identity.bitwarden.com"
+pushNotifications: 
+  ## @param pushNotifications.existingSecret Name of an existing secret containing the Bitwarden installation id and key
+  ##
+  existingSecret: ""
+  ## @extra pushNotifications.installationId Installation Id for mobile push notifications
+  ##
+  installationId: 
+    ## @param pushNotifications.installationId.value Bitwarden installation id string
+    ## Example: installationIdGoesHere
+    ##
+    value: ""
+    ## @param pushNotifications.installationId.existingSecretKey When using an existing secret, specify the key which contains the installation id.
+    ## Example: INSTALLATION_ID
+    ## 
+    existingSecretKey: ""
+  ## @extra pushNotifications.installationKey Installation Key for mobile push notifications
+  installationKey:
+    ## @param pushNotifications.installationKey.value Bitwarden installation key string
+    ## Example: superSecretInstallationKey
+    ##
+    value: ""
+    ## @param pushNotifications.installationKey.existingSecretKey When using an existing secret, specify the key which contains the installation key.
+    ## Example: INSTALLATION_KEY
+    ##
+    existingSecretKey: ""
+  ## @param pushNotifications.relayUri Change Bitwarden relay uri.
+  ## Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
+  ## 
+  relayUri: "https://push.bitwarden.com"
+  ## @param pushNotifications.identityUri Change Bitwarden identity uri.
+  ## Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
+  ## 
+  identityUri: "https://identity.bitwarden.com"
 
 ## @section Scheduled jobs
 ##


### PR DESCRIPTION
Enable use of existing secrets for bitwarden installation id and key for push notifications.
Both, installation key and id, shouldn't be made public when deploying via gitops. This enables using a seperate (encrypted) secret for defining installation id and key.

Based on the smtp configuration

New section in values.yaml looks the following:
```
pushNotifications: 
  existingSecret: ""
  installationId: 
    value: ""
    existingSecretKey: ""
  installationKey:
    value: ""
    existingSecretKey: ""
  relayUri: "https://push.bitwarden.com"
  identityUri: "https://identity.bitwarden.com"
```

It is possible to specify a string value in installationId.value or installationKey.value.

My implementation contains a breaking change due to the indroduction of installationId.value and installationKey.value instead of defining the id and key directly.