### PR TITLE
fix: add flag to enable notifications service

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.24.2
+version: 0.24.3
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -339,6 +339,7 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 
 | Name                                                  | Description                                                                         | Value                            |
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------- |
+| `pushNotifications.enabled`                           | Enable the push notification service                                                | `false`                          |
 | `pushNotifications.existingSecret`                    | Name of an existing secret containing the Bitwarden installation id and key         | `""`                             |
 | `pushNotifications.installationId.value`              | Bitwarden installation id string                                                    | `""`                             |
 | `pushNotifications.installationId.existingSecretKey`  | When using an existing secret, specify the key which contains the installation id.  | `""`                             |

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -53,7 +53,7 @@ data:
   INVITATION_ORG_NAME: {{ .Values.invitationOrgName | quote }}
   ICON_BLACKLIST_NON_GLOBAL_IPS: {{ .Values.iconBlacklistNonGlobalIps | quote }}
   IP_HEADER: {{ .Values.ipHeader | quote }}
-  {{- if .Values.pushNotifications }}
+  {{- if .Values.pushNotifications.enabled }}
   PUSH_ENABLED: "true"
   {{- with .Values.pushNotifications.relayUri }}
   PUSH_RELAY_URI: {{ . | quote }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -297,18 +297,21 @@ database:
 ## Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
 ##
 
-pushNotifications: 
+pushNotifications:
+  ## @param pushNotifications.enabled Enable the push notification service
+  ##
+  enabled: false
   ## @param pushNotifications.existingSecret Name of an existing secret containing the Bitwarden installation id and key
   ##
   existingSecret: ""
-  installationId: 
+  installationId:
     ## @param pushNotifications.installationId.value Bitwarden installation id string
     ## Example: installationIdGoesHere
     ##
     value: ""
     ## @param pushNotifications.installationId.existingSecretKey When using an existing secret, specify the key which contains the installation id.
     ## Example: INSTALLATION_ID
-    ## 
+    ##
     existingSecretKey: ""
   installationKey:
     ## @param pushNotifications.installationKey.value Bitwarden installation key string
@@ -321,11 +324,11 @@ pushNotifications:
     existingSecretKey: ""
   ## @param pushNotifications.relayUri Change Bitwarden relay uri.
   ## Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
-  ## 
+  ##
   relayUri: "https://push.bitwarden.com"
   ## @param pushNotifications.identityUri Change Bitwarden identity uri.
   ## Refer to https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification for details
-  ## 
+  ##
   identityUri: "https://identity.bitwarden.com"
 
 ## @section Scheduled jobs


### PR DESCRIPTION
With the introduction of the push notification keys in PR #106, the check for value `pushNotifications` started to return true by default, which breaks installations that do not have notifications configured.

To fix this, we're introducing a new flag `pushNotifications.enabled` to set this feature on, `false` by default.

When updating to this version, please add the flag to your values file:

```yaml
...
pushNotifications:
  enabled: true
...
