### PR TITLE
chore: Bump Vaultwarden App version to 1.32.2

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -8,10 +8,10 @@ keywords:
 sources:
   - https://github.com/guerzon/vaultwarden
   - https://github.com/dani-garcia/vaultwarden
-appVersion: 1.32.1
+appVersion: 1.32.2
 maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.29.1
+version: 0.29.2
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -13,7 +13,7 @@ image:
   ## @param image.tag Vaultwarden image tag
   ## Ref: https://hub.docker.com/r/vaultwarden/server/tags
   ##
-  tag: "1.32.1-alpine"
+  tag: "1.32.2-alpine"
   ## @param image.pullPolicy Vaultwarden image pull policy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
This pull request includes the following changes:

- Bumped Vaultwarden app version to 1.32.2 in the Helm chart to ensure compatibility with the latest features and fixes.
- Updated Helm chart version to 0.29.2 to reflect the changes in the app version and maintain version consistency.

Testing:
The changes have been tested, and the functionality works as expected with the updated Vaultwarden version. No issues were encountered during deployment or runtime.

Please review and let me know if any adjustments are needed!