### PR TITLE
Add probe override support

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.29.2
+version: 0.29.3
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -344,31 +344,34 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 
 ### Reliability configuration
 
-| Name                                 | Description                                                             | Value   |
-| ------------------------------------ | ----------------------------------------------------------------------- | ------- |
-| `livenessProbe.enabled`              | Enable liveness probe                                                   | `true`  |
-| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                | `5`     |
-| `livenessProbe.timeoutSeconds`       | How long to wait for the probe to succeed                               | `1`     |
-| `livenessProbe.periodSeconds`        | How often to perform the probe                                          | `10`    |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful | `1`     |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed      | `10`    |
-| `readinessProbe.enabled`             | Enable readiness probe                                                  | `true`  |
-| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                               | `5`     |
-| `readinessProbe.timeoutSeconds`      | How long to wait for the probe to succeed                               | `1`     |
-| `readinessProbe.periodSeconds`       | How often to perform the probe                                          | `10`    |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful | `1`     |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed      | `3`     |
-| `startupProbe.enabled`               | Enable startup probe                                                    | `false` |
-| `startupProbe.initialDelaySeconds`   | Delay before startup probe is initiated                                 | `5`     |
-| `startupProbe.timeoutSeconds`        | How long to wait for the probe to succeed                               | `1`     |
-| `startupProbe.periodSeconds`         | How often to perform the probe                                          | `10`    |
-| `startupProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful | `1`     |
-| `startupProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed      | `10`    |
-| `resources`                          | Resource configurations                                                 | `{}`    |
-| `strategy`                           | Resource configurations                                                 | `{}`    |
-| `podDisruptionBudget.enabled`        | Enable PodDisruptionBudget settings                                     | `false` |
-| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled.         | `1`     |
-| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable          | `nil`   |
+| Name                                 | Description                                                               | Value    |
+|--------------------------------------|---------------------------------------------------------------------------|----------|
+| `livenessProbe.enabled`              | Enable liveness probe                                                     | `true`   |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                  | `5`      |
+| `livenessProbe.timeoutSeconds`       | How long to wait for the probe to succeed                                 | `1`      |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                                            | `10`     |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful   | `1`      |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed        | `10`     |
+| `livenessProbe.path`                 | Path which probe tries to resolve, override when non-root path deployment | `/alive` |
+| `readinessProbe.enabled`             | Enable readiness probe                                                    | `true`   |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                 | `5`      |
+| `readinessProbe.timeoutSeconds`      | How long to wait for the probe to succeed                                 | `1`      |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                            | `10`     |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful   | `1`      |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed        | `3`      |
+| `readinessProbe.path`                | Path which probe tries to resolve, override when non-root path deployment | `/alive` |
+| `startupProbe.enabled`               | Enable startup probe                                                      | `false`  |
+| `startupProbe.initialDelaySeconds`   | Delay before startup probe is initiated                                   | `5`      |
+| `startupProbe.timeoutSeconds`        | How long to wait for the probe to succeed                                 | `1`      |
+| `startupProbe.periodSeconds`         | How often to perform the probe                                            | `10`     |
+| `startupProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful   | `1`      |
+| `startupProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed        | `10`     |
+| `startupProbe.path`                  | Path which probe tries to resolve, override when non-root path deployment | `/alive` |
+| `resources`                          | Resource configurations                                                   | `{}`     |
+| `strategy`                           | Resource configurations                                                   | `{}`     |
+| `podDisruptionBudget.enabled`        | Enable PodDisruptionBudget settings                                       | `false`  |
+| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled.           | `1`      |
+| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable            | `nil`    |
 
 ### Persistent data configuration
 

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -138,7 +138,7 @@ containers:
     {{- if .Values.livenessProbe.enabled }}
     livenessProbe:
       httpGet:
-        path: /alive
+        path: {{ .Values.livenessProbe.path }}
         port: http
       initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
       periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -149,7 +149,7 @@ containers:
     {{- if .Values.readinessProbe.enabled }}
     readinessProbe:
       httpGet:
-        path: /alive
+        path: {{ .Values.readinessProbe.path }}
         port: http
       initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
       periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -160,7 +160,7 @@ containers:
     {{- if .Values.startupProbe.enabled }}
     startupProbe:
       httpGet:
-        path: /alive
+        path: {{ .Values.startupProbe.path }}
         port: http
       initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
       periodSeconds: {{ .Values.startupProbe.periodSeconds }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -153,6 +153,9 @@ livenessProbe:
   ## @param livenessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed
   ##
   failureThreshold: 10
+  ## @param livenessProbe.path Path on which the probe is exposed, default is "/alive". Replace when using non-root path deployment
+  ##
+  path: /alive
 
 ## Readiness probe configuration
 ##
@@ -175,6 +178,9 @@ readinessProbe:
   ## @param readinessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed
   ##
   failureThreshold: 3
+  ## @param readinessProbe.path Path on which the probe is exposed, default is "/alive". Replace when using non-root path deployment
+  ##
+  path: /alive
 
 ## Startup probe configuration
 ##
@@ -197,6 +203,9 @@ startupProbe:
   ## @param startupProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed
   ##
   failureThreshold: 10
+  ## @param startupProbe.path Path on which the probe is exposed, default is "/alive". Replace when using non-root path deployment
+  ##
+  path: /alive
 
 ## @param resources Resource configurations
 ##


### PR DESCRIPTION
Hi,

I just deployed Vaultwarden using chart, I configured Vaultwarden to run on non root path (/vaultwarden), this however causes the pod to be restarted since the chart deployment probe checks only /alive which needs to be /vaultwarden/alive in my case.

This chart fixes that problem and allows the probe URL to be set.