### PR TITLE
added sticky session & loadbalancer service

### DIFF
--- a/charts/vaultwarden/templates/service.yaml
+++ b/charts/vaultwarden/templates/service.yaml
@@ -25,4 +25,9 @@ spec:
       targetPort: 8080
 {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800
+  type: LoadBalancer
 {{- end }}


### PR DESCRIPTION
As requested:
https://github.com/guerzon/vaultwarden/issues/27#issuecomment-2445760165

Unfortunatley I am not very familiar with creating Helm charts as I created the loadbalancer service as a regular kubernetes yaml.