### PR TITLE
feat: Add support for running multiple replicas

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.29.4
+version: 0.30.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -155,6 +155,20 @@ Visit [this](https://medium.com/@sreafterhours/deploy-vaultwarden-to-amazon-eks-
 
 Detailed configuration options can be found in the [Exposure Settings](#exposure-settings) section.
 
+## High Availability
+
+Set the following to run multiple deployment/statefulset replicas:
+
+```yaml
+replicas: 10
+
+service:
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800
+```
+
 ## Security
 
 ### Admin page
@@ -285,7 +299,7 @@ data:
 To use persistent storage for attachments, set the `attachments` dictionary. Optionally set a different path. Note that by default, the path is `/data/attachments`.
 
 ```yaml
-data:
+attachments:
   name: "vaultwarden-data"
   size: "15Gi"
   class: "local-path"
@@ -295,7 +309,7 @@ In case you want to keep the existing persistent volume claim during uninstall a
 (This will be ignored for StatefulSets and is only relevant for `resourceType: Deployment`)
 
 ```yaml
-data:
+attachments:
   name: "vaultwarden-data"
   size: "15Gi"
   class: "local-path"

--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: vaultwarden

--- a/charts/vaultwarden/templates/service.yaml
+++ b/charts/vaultwarden/templates/service.yaml
@@ -26,3 +26,10 @@ spec:
 {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
 {{- end }}
+{{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+{{- end }}
+{{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig:
+  {{- toYaml .Values.service.sessionAffinityConfig | nindent 4 }}
+{{- end }}

--- a/charts/vaultwarden/templates/statefulset.yaml
+++ b/charts/vaultwarden/templates/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   serviceName: vaultwarden
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: vaultwarden

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -40,6 +40,10 @@ image:
   ##
   extraVars: []
 
+## @param replicas Number of deployment replicas
+##
+replicas: 1
+
 ## @param fullnameOverride String to override the application name.
 ##
 fullnameOverride: ""
@@ -691,7 +695,18 @@ service:
   ##
   labels: {}
   ## @param service.ipFamilyPolicy IP family policy for the service
+  ##
   ipFamilyPolicy: "SingleStack"
+  ## @param service.sessionAffinity Session affinity
+  ##
+  # sessionAffinity: ClientIP
+  sessionAffinity: ""
+  ## @param service.sessionAffinity Session affinity configuration
+  ##
+  sessionAffinityConfig: {}
+  # sessionAffinityConfig:
+  #   clientIP:
+  #     timeoutSeconds: 10800
 
 ## Ingress configuration
 ## Refer to the README for some examples


### PR DESCRIPTION
Fixes #27.

Note: this PR does not address concurrent disk access for `data` and `attachment` volumes, which anyway is not the responsibility of the Helm chart. It is the responsibility of the Kubernetes administrator to ensure the storage class used is capable of supporting read and/or writes from multiple pods.