### PR TITLE
Adding Support For Existing PVC

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.30.1
+version: 0.30.2
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.30.2
+version: 0.31.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -324,6 +324,13 @@ In case you want to use an existing PVC to store your data and attachments (i.e.
 which will update the PodSpec's to use the provided PVC.  Note, that use of this value will ignore the values of both `storage.data` 
 and `storage.attachments` values.
 
+```yaml
+existingVolumeClaim:
+    claimName: "vaultwarden-pvc"
+    dataPath: "/data"
+    attachmentsPath: /data/attachments
+```
+
 ## Uninstall
 
 To uninstall/delete the `vaultwarden-demo` release:

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -275,9 +275,11 @@ Detailed configuration options can be found in the [SMTP Configuration](#smtp-co
 
 ## Persistent storage
 
+### Building Persistant Storage Through Helm
+
 Vaultwarden requires persistent storage for its attachments and icons cache.
 
-To use persistent storage using a claim, set the `data` dictionary. Optionally set a different path using the `path` key. The following example sets the storage class to an already-installed Rancher's [local path storage](https://github.com/rancher/local-path-provisioner) provisioner.
+To use persistent storage using a claim, set the `storage.data` dictionary. Optionally set a different path using the `path` key. The following example sets the storage class to an already-installed Rancher's [local path storage](https://github.com/rancher/local-path-provisioner) provisioner.
 
 ```yaml
 data:
@@ -296,7 +298,7 @@ data:
   path: "/srv/vaultwarden-data"
 ```
 
-To use persistent storage for attachments, set the `attachments` dictionary. Optionally set a different path. Note that by default, the path is `/data/attachments`.
+To use persistent storage for attachments, set the `storage.attachments` dictionary. Optionally set a different path. Note that by default, the path is `/data/attachments`.
 
 ```yaml
 attachments:
@@ -315,6 +317,12 @@ attachments:
   class: "local-path"
   keepPvc: true
 ```
+
+### Using an Existing Persistent Volume Claim
+
+In case you want to use an existing PVC to store your data and attachments (i.e. NAS), `storage.existingVolumeClaim` can be set 
+which will update the PodSpec's to use the provided PVC.  Note, that use of this value will ignore the values of both `storage.data` 
+and `storage.attachments` values.
 
 ## Uninstall
 

--- a/charts/vaultwarden/templates/_helpers.tpl
+++ b/charts/vaultwarden/templates/_helpers.tpl
@@ -85,7 +85,7 @@ Determine whether to use deployment or statefulset
 {{- if .Values.resourceType }}
 {{- .Values.resourceType }}
 {{- else }}
-{{- if (and .Values.data (ne .Values.database.type "default")) }}
+{{- if (and (or .Values.storage.data .Values.storage.existingVolumeClaim) (ne .Values.database.type "default")) }}
 {{- "Deployment" }}
 {{- else }}
 {{- "StatefulSet" }}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -171,6 +171,12 @@ containers:
     {{- with .Values.sidecars }}
     {{- toYaml . | nindent 2 }}
     {{- end }}
+{{- if .Values.storage.existingVolumeClaim }}
+volumes:
+  - name: vaultwarden-data
+    persistentVolumeClaim:
+      claimName: {{ .Values.storage.existingVolumeClaim }}
+{{- end }}
 {{- if .Values.serviceAccount.create }}
 serviceAccountName: {{ .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -128,11 +128,11 @@ containers:
     {{- if or (.Values.storage.data) (.Values.storage.attachments) }}
     volumeMounts:
       {{- with .Values.storage.data }}
-      - name: vaultwarden-data
+      - name: {{ .name }}
         mountPath: {{ default "/data" .path }}
       {{- end }}
       {{- with .Values.storage.attachments }}
-      - name: vaultwarden-data
+      - name: {{ .name }}
         mountPath: {{ default "/data/attachments" .path }}
       {{- end }}
     {{- end }}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -119,11 +119,13 @@ containers:
         name: http
         protocol: TCP
     {{- if .Values.storage.existingVolumeClaim }}
+    {{- with .Values.storage.existingVolumeClaim }}
     volumeMounts:
       - name: vaultwarden-data
-        mountPath: {{ default "/data" .path }}
+        mountPath: {{ default "/data" .dataPath }}
       - name: vaultwarden-data
-        mountPath: {{ default "/data/attachments" .path }}
+        mountPath: {{ default "/data/attachments" .attachmentsPath }}
+    {{- end }}
     {{- else }}
     {{- if or (.Values.storage.data) (.Values.storage.attachments) }}
     volumeMounts:
@@ -180,10 +182,12 @@ containers:
     {{- toYaml . | nindent 2 }}
     {{- end }}
 {{- if .Values.storage.existingVolumeClaim }}
+{{- with .Values.storage.existingVolumeClaim }}
 volumes:
   - name: vaultwarden-data
     persistentVolumeClaim:
-      claimName: {{ .Values.storage.existingVolumeClaim }}
+      claimName: {{ .claimName }}
+{{- end }}
 {{- end }}
 {{- if .Values.serviceAccount.create }}
 serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -121,11 +121,11 @@ containers:
     {{- if or (.Values.data) (.Values.attachments) }}
     volumeMounts:
       {{- with .Values.data }}
-      - name: {{ .name }}
+      - name: vaultwarden-data
         mountPath: {{ default "/data" .path }}
       {{- end }}
       {{- with .Values.attachments }}
-      - name: {{ .name }}
+      - name: vaultwarden-data
         mountPath: {{ default "/data/attachments" .path }}
       {{- end }}
     {{- end }}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -118,16 +118,24 @@ containers:
       - containerPort: 8080
         name: http
         protocol: TCP
-    {{- if or (.Values.data) (.Values.attachments) }}
+    {{- if .Values.storage.existingVolumeClaim }}
     volumeMounts:
-      {{- with .Values.data }}
+      - name: vaultwarden-data
+        mountPath: {{ default "/data" .path }}
+      - name: vaultwarden-data
+        mountPath: {{ default "/data/attachments" .path }}
+    {{- else }}
+    {{- if or (.Values.storage.data) (.Values.storage.attachments) }}
+    volumeMounts:
+      {{- with .Values.storage.data }}
       - name: vaultwarden-data
         mountPath: {{ default "/data" .path }}
       {{- end }}
-      {{- with .Values.attachments }}
+      {{- with .Values.storage.attachments }}
       - name: vaultwarden-data
         mountPath: {{ default "/data/attachments" .path }}
       {{- end }}
+    {{- end }}
     {{- end }}
     resources:
     {{- toYaml .Values.resources | nindent 6 }}

--- a/charts/vaultwarden/templates/_pvcSpec.tpl
+++ b/charts/vaultwarden/templates/_pvcSpec.tpl
@@ -1,7 +1,7 @@
 {{- define "vaultwarden.pvcSpec" }}
-{{- if (or .Values.data .Values.attachments) -}}
+{{- if (or .Values.storage.data .Values.storage.attachments) -}}
 volumeClaimTemplates:
-  {{- with .Values.data }}
+  {{- with .Values.storage.data }}
   - metadata:
       name: {{ .name }}
       labels:
@@ -24,7 +24,7 @@ volumeClaimTemplates:
       storageClassName: {{ . | quote }}
       {{- end }}
   {{- end }}
-  {{- with .Values.attachments }}
+  {{- with .Values.storage.attachments }}
   - metadata:
       name: {{ .name }}
       labels:

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -34,11 +34,11 @@ data:
   SMTP_ACCEPT_INVALID_HOSTNAMES: {{ .Values.smtp.acceptInvalidHostnames | quote }}
   SMTP_ACCEPT_INVALID_CERTS: {{ .Values.smtp.acceptInvalidCerts | quote }}
   {{- end }}
-  {{- if .Values.data }}
-  DATA_FOLDER: {{ default "/data" .Values.data.path | quote }}
+  {{- if .Values.storage.data }}
+  DATA_FOLDER: {{ default "/data" .Values.storage.data.path | quote }}
   {{- end }}
-  {{- if .Values.attachments }}
-  ATTACHMENTS_FOLDER: {{ default "/data/attachments" .Values.attachments.path | quote }}
+  {{- if .Values.storage.attachments }}
+  ATTACHMENTS_FOLDER: {{ default "/data/attachments" .Values.storage.attachments.path | quote }}
   {{- end }}
   ROCKET_ADDRESS: {{ .Values.rocket.address | quote }}
   ROCKET_PORT: {{ .Values.rocket.port | quote }}

--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -40,11 +40,11 @@ spec:
         {{- end }}
     spec:
       {{- include "vaultwarden.podSpec" . | nindent 6 }}
+      {{- range $pvc := (fromYaml (include "vaultwarden.pvcSpec" .)).volumeClaimTemplates }}
       volumes:
-        {{- range $pvc := (fromYaml (include "vaultwarden.pvcSpec" .)).volumeClaimTemplates }}
         {{- $newName := printf "%s-%s-0" $pvc.metadata.name $.Release.Name }}
         - name: {{ $pvc.metadata.name }}
           persistentVolumeClaim:
             claimName: {{ $newName }}
-        {{- end }}
+      {{- end }}
 {{- end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -248,28 +248,32 @@ podDisruptionBudget:
 ## @section Persistent data configuration
 ##
 
-## @param data Data directory configuration, refer to values.yaml for parameters.
-##
-data:
-  {}
-  # name: "vaultwarden-data"
-  # size: "15Gi"
-  # class: ""
-  # path: "/data"
-  # keepPvc: false
-  # accessMode: "ReadWriteOnce"
 
-## @param attachments Attachments directory configuration, refer to values.yaml for parameters.
-## By default, attachments/ is located inside the data directory.
-##
-attachments:
-  {}
-  # name: "vaultwarden-files"
-  # size: "100Gi"
-  # class: ""
-  # path: /files
-  # keepPvc: false
-  # accessMode: "ReadWriteOnce"
+storage:
+  existingVolumeClaim: ""
+  
+  ## @param data Data directory configuration, refer to values.yaml for parameters.
+  ##
+  data:
+    {}
+    # name: "vaultwarden-data"
+    # size: "15Gi"
+    # class: ""
+    # path: "/data"
+    # keepPvc: false
+    # accessMode: "ReadWriteOnce"
+
+  ## @param attachments Attachments directory configuration, refer to values.yaml for parameters.
+  ## By default, attachments/ is located inside the data directory.
+  ##
+  attachments:
+    {}
+    # name: "vaultwarden-files"
+    # size: "100Gi"
+    # class: ""
+    # path: /files
+    # keepPvc: false
+    # accessMode: "ReadWriteOnce"
 
 ## @param webVaultEnabled Enable Web Vault
 ##
@@ -707,9 +711,6 @@ service:
   # sessionAffinityConfig:
   #   clientIP:
   #     timeoutSeconds: 10800
-
-storage:
-  existingVolumeClaim: ""
 
 ## Ingress configuration
 ## Refer to the README for some examples

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -250,11 +250,15 @@ podDisruptionBudget:
 
 
 storage:
-  ## @param existingVolumeClaim If defined, the value here will be used for the data and
+  ## @param existingVolumeClaim If defined, the values here will be used for the data and
   ## attachments PV's. The custom values for data and attachments will be ignored if
   ## a value is set here
   ##
-  existingVolumeClaim: ""
+  existingVolumeClaim:
+    {}
+    # claimName: "vaultwarden-pvc"
+    # dataPath: "/data"
+    # attachmentsPath: /data/attachments
 
   ## @param data Data directory configuration, refer to values.yaml for parameters.
   ##

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -708,6 +708,9 @@ service:
   #   clientIP:
   #     timeoutSeconds: 10800
 
+storage:
+  existingVolumeClaim: ""
+
 ## Ingress configuration
 ## Refer to the README for some examples
 ##

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -250,7 +250,7 @@ podDisruptionBudget:
 
 
 storage:
-  ## @param existingVolumeClaim If defined, the value here will be used for the data and 
+  ## @param existingVolumeClaim If defined, the value here will be used for the data and
   ## attachments PV's. The custom values for data and attachments will be ignored if
   ## a value is set here
   ##

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -250,8 +250,12 @@ podDisruptionBudget:
 
 
 storage:
+  ## @param existingVolumeClaim If defined, the value here will be used for the data and 
+  ## attachments PV's. The custom values for data and attachments will be ignored if
+  ## a value is set here
+  ##
   existingVolumeClaim: ""
-  
+
   ## @param data Data directory configuration, refer to values.yaml for parameters.
   ##
   data:


### PR DESCRIPTION
Added support for existing PVC's.  This is a more up to date version of a lot of the enhancements made in the following PR, but recreated for a more fresh PR https://github.com/guerzon/vaultwarden/pull/19 .

## Note:
This is a breaking change as the `data` and `attachment` objects have been moved under a `storage` key.  