### PR TITLE
Fix issue where pvc range produced multiple volume keys

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.31.0
+version: 0.31.1
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -40,11 +40,13 @@ spec:
         {{- end }}
     spec:
       {{- include "vaultwarden.podSpec" . | nindent 6 }}
-      {{- range $pvc := (fromYaml (include "vaultwarden.pvcSpec" .)).volumeClaimTemplates }}
+      {{- if not .Values.storage.existingVolumeClaim }}
       volumes:
+        {{- range $pvc := (fromYaml (include "vaultwarden.pvcSpec" .)).volumeClaimTemplates }}
         {{- $newName := printf "%s-%s-0" $pvc.metadata.name $.Release.Name }}
         - name: {{ $pvc.metadata.name }}
           persistentVolumeClaim:
             claimName: {{ $newName }}
+        {{- end }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Resolves #135 

Confirmed the following via tests:
- Inclusion of `storage.existingVolumeClaim` does not create a `volume` key in the deployment
- Omitting `storage.existingVolumeClaim` and creating either/or/both of `storage.data / storage.attachments` creates a single `volume` key with children for each

![image](https://github.com/user-attachments/assets/d915843d-c089-4ea0-a33e-2a6cd787386a)

(dont judge my test keys lol as i had to spoof the volumeClaim names to avoid errors with `includes` in my test)