### PR TITLE
feat(helm): support optional image registry in template rendering

### DIFF
--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -27,7 +27,7 @@ initContainers:
 enableServiceLinks: false
 {{- end }}
 containers:
-  - image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+  - image: {{ if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
     name: vaultwarden
     envFrom:


### PR DESCRIPTION
To automatically update images, I added the registry in front of the image and set the registry default to empty. 
This leaves me with an extra / in front of it since there is no check to see if the registry is filled. 

