### PR TITLE
Fix recursing volume mounts when using `storage.existingVolumeClaim`

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.31.2
+version: 0.31.3
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -326,9 +326,8 @@ and `storage.attachments` values.
 
 ```yaml
 existingVolumeClaim:
-    claimName: "vaultwarden-pvc"
-    dataPath: "/data"
-    attachmentsPath: /data/attachments
+  claimName: "vaultwarden-pvc"
+  mountPath: "/data"
 ```
 
 ## Uninstall

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -122,9 +122,7 @@ containers:
     {{- with .Values.storage.existingVolumeClaim }}
     volumeMounts:
       - name: vaultwarden-data
-        mountPath: {{ default "/data" .dataPath }}
-      - name: vaultwarden-data
-        mountPath: {{ default "/data/attachments" .attachmentsPath }}
+        mountPath: {{ default "/data" .mountPath }}
     {{- end }}
     {{- else }}
     {{- if or (.Values.storage.data) (.Values.storage.attachments) }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -257,8 +257,7 @@ storage:
   existingVolumeClaim:
     {}
     # claimName: "vaultwarden-pvc"
-    # dataPath: "/data"
-    # attachmentsPath: /data/attachments
+    # mountPath: "/data"
 
   ## @param data Data directory configuration, refer to values.yaml for parameters.
   ##


### PR DESCRIPTION
This PR fixes #139, which causes a recursing volume mounts when using `storage.existingVolumeClaim`. For this reason, Bitwarden did not find the attachment files.
