### PR TITLE
Add SSO configuration support to helm chart

### DIFF
--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -559,3 +559,27 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `ingress.tlsSecret`               | Kubernetes secret containing the SSL certificate when using the "nginx" class. | `""`                 |
 | `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                 |
 | `ingress.customHeadersConfigMap`  | ConfigMap containing custom headers to be added to the ingress.                | `{}`                 |
+
+### SSO OpenID Connect Configuration
+
+| Name                                 | Description                                                                    | Value                |
+| ------------------------------------ | ------------------------------------------------------------------------------ | -------------------- |
+| `sso.enabled`                        | Enables the SSO OpenID Connect configuration                                   | `false`              |
+| `sso.existingSecret`                 | Name of an existing secret containing the OpenID Connect client id and secret  | `""`                 |
+| `sso.onlySSO`                        | Disable the email+master-password login flow                                   | `false`              |
+| `sso.enforceSSO`                     | Show SSO login by default and don't ask for the users email                    | `false`              |
+| `sso.signupsMatchEmail`              | If SSO user signup should take control of existing account with given mail     | `false`              |
+| `sso.ignoreEmailVerification`        | Allow signup without mail verification (if claim `email_verified` is missing)  | `false`              |
+| `sso.authority`                      | The OpenID Discovery endpoint (without '/.well-known/openid-configuration')    | `""`                 |
+| `sso.scopes`                         | OpenID connect token scopes to use during requests                             | `"email profile"`    |
+| `sso.authorizeExtraParams`           | OpenID connect extra params fort he authorize redirect                         | `""`                 |
+| `sso.pkce`                           | Enable/Disable PKCE support for the authentication flow                        | `true`               |
+| `sso.trustedAudience`                | The Audience to trust for the ID token. (`client_id` is always trusted)        | `""`                 |
+| `sso.masterPasswordPolicy`           | The Master password policy for SSO ('enforceOnLogin' is not supported)         | `""`                 |
+| `sso.disableSessionHandling`         | Disable SSO session handling if you can not retrieve refresh_tokens from IDP   | `false`              |
+| `sso.cacheExpiration`                | Expiration time for SSO client cache, passing 0 disables the cache             | `0`                  |
+| `sso.debugTokens`                    | Enbable token logging to debug, vaultwarden log level must be set to default   | `false`              |
+| `sso.clientId.value`                 | Client ID string for the OpenID Connect Provider                               | `""`                 |
+| `sso.clientId.existingSecretKey`     | When using an existing secret, specify the key which contains the client ID    | `""`                 |
+| `sso.clientSecret.value`             | Client secret string for the OpenID Connect Provider                           | `""`                 |
+| `sso.clientSecret.existingSecretKey` | When using existing secret, specify the key which contains the client secret   | `""`                 |

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -583,3 +583,12 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `sso.clientId.existingSecretKey`     | When using an existing secret, specify the key which contains the client ID    | `""`                 |
 | `sso.clientSecret.value`             | Client secret string for the OpenID Connect Provider                           | `""`                 |
 | `sso.clientSecret.existingSecretKey` | When using existing secret, specify the key which contains the client secret   | `""`                 |
+| `sso.roles.enabled`                  | Enable role mapping from ID token claim (supports role "admin" and "user")     | `false`              |
+| `sso.roles.defaultToUser`            | Assign user role as fallback if no role found (users without role can't login) | `true`               |
+| `sso.roles.tokenPath`                | Specify the path to the roles claim inside the ID token                        | `""`                 |
+| `sso.organizations.enabled`          | Enable automatic organization mapping for SSO users.                           | `false`              |
+| `sso.organizations.inviteAll`        | Enable automatic invitation to all organizations in vaultwarden                | `false`               |
+| `sso.organizations.inviteAutoAccept` | Enable automatic acceptance of organization invites                            | `false`               |
+| `sso.organizations.enableRevocation` | Control if user membership from organizations can be revoked by the IDP        | `false`               |
+| `sso.organizations.tokenPath`        | Specify the path to the roles claim inside the ID token.                       | `""`                 |
+| `sso.organizations.mappings`         | Used to map group id's from a IDP. (format: "sso-id:vw-id;", seperated by ";") | `""`                 |

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -75,6 +75,20 @@ containers:
             name: {{ default (include "vaultwarden.fullname" .) .Values.smtp.existingSecret }}
             key: {{ default "SMTP_PASSWORD" .Values.smtp.password.existingSecretKey }}
       {{- end }}
+      {{- if and .Values.sso.enabled (or (.Values.sso.clientId.value) (.Values.sso.clientId.existingSecretKey) )}}
+      - name: SSO_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: {{ default (include "vaultwarden.fullname" .) .Values.sso.existingSecret }}
+            key: {{ default "SSO_CLIENT_ID" .Values.sso.clientId.existingSecretKey }}
+      {{- end }}
+      {{- if and .Values.sso.enabled (or (.Values.sso.clientId.value) (.Values.sso.clientSecret.existingSecretKey) )}}
+      - name: SSO_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: {{ default (include "vaultwarden.fullname" .) .Values.sso.existingSecret }}
+            key: {{ default "SSO_CLIENT_SECRET" .Values.sso.clientSecret.existingSecretKey }}
+      {{- end }}
       {{- if .Values.adminToken }}
       - name: ADMIN_TOKEN
         valueFrom:

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -122,3 +122,23 @@ data:
   EMAIL_CHANGE_ALLOWED: {{ .Values.emailChangeAllowed | quote }}
   ADMIN_RATELIMIT_SECONDS: {{ .Values.adminRateLimitSeconds | quote }}
   ADMIN_RATELIMIT_MAX_BURST: {{ .Values.adminRateLimitMaxBurst | quote }}
+  {{- if .Values.sso.enabled }}
+  SSO_ENABLED: {{ .Values.sso.enabled | quote }}
+  SSO_ONLY: {{ .Values.sso.onlySSO | quote }}
+  SSO_SIGNUPS_MATCH_EMAIL: {{ .Values.sso.signupsMatchEmail | quote }}
+  SSO_ALLOW_UNKNOWN_EMAIL_VERIFICATION: {{ .Values.sso.ignoreEmailVerification | quote }}
+  SSO_AUTHORITY: {{ .Values.sso.authority | quote }}
+  SSO_SCOPES: {{ .Values.sso.scopes | quote }}
+  SSO_AUTHORIZE_EXTRA_PARAMS: {{ .Values.sso.authorizeExtraParams | quote }}
+  SSO_PKCE: {{ .Values.sso.pkce | quote }}
+  SSO_AUDIENCE_TRUSTED: {{ .Values.sso.trustedAudience | quote }}
+  {{- if .Values.sso.masterPasswordPolicy }}
+  SSO_MASTER_PASSWORD_POLICY: {{ .Values.sso.masterPasswordPolicy | quote }}
+  {{- end }}
+  SSO_AUTH_ONLY_NOT_SESSION: {{ .Values.sso.authOnly | quote }}
+  SSO_CLIENT_CACHE_EXPIRATION: {{ .Values.sso.cacheExpiration | quote }}
+  SSO_DEBUG_TOKENS: {{ .Values.sso.debugTokens | quote }}
+  {{- if .Values.sso.enforceSSO }}
+  SSO_FRONTEND: "override"
+  {{- end }}
+  {{- end }}

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -141,4 +141,15 @@ data:
   {{- if .Values.sso.enforceSSO }}
   SSO_FRONTEND: "override"
   {{- end }}
+  SSO_ROLES_ENABLED: {{ .Values.sso.roles.enabled | quote }}
+  SSO_ROLES_DEFAULT_TO_USER: {{ .Values.sso.roles.defaultToUser | quote }}
+  SSO_ROLES_TOKEN_PATH: {{ .Values.sso.roles.tokenPath | quote }}
+  SSO_ORGANIZATIONS_INVITE: {{ .Values.sso.organizations.enabled | quote }}
+  SSO_ORGANIZATIONS_REVOCATION: {{ .Values.sso.organizations.enableRevocation | quote }}
+  SSO_ORGANIZATIONS_TOKEN_PATH: {{ .Values.sso.organizations.tokenPath | quote }}
+  SSO_ORGANIZATIONS_ID_MAPPING: {{ .Values.sso.organizations.mappings | quote }}
+  SSO_ORGANIZATIONS_ALL_COLLECTIONS: {{ .Values.sso.organizations.inviteAll | quote }}
+  {{- if .Values.sso.organizations.inviteAutoAccept }}
+  ORGANIZATION_INVITE_AUTO_ACCEPT: {{ .Values.sso.organizations.inviteAutoAccept | quote }}
+  {{- end }}
   {{- end }}

--- a/charts/vaultwarden/templates/secrets.yaml
+++ b/charts/vaultwarden/templates/secrets.yaml
@@ -22,6 +22,10 @@ data:
   SMTP_PASSWORD: {{ .Values.smtp.password.value | b64enc | quote }}
   SMTP_USERNAME: {{ .Values.smtp.username.value | b64enc | quote }}
   {{- end }}
+  {{- if and .Values.sso.enabled (not ( .Values.sso.existingSecret )) }}
+  SSO_CLIENT_ID: {{ .Values.sso.clientId.value | b64enc | quote }}
+  SSO_CLIENT_SECRET: {{ .Values.sso.clientSecret.value | b64enc | quote }}
+  {{- end }}
   {{- if not ( .Values.pushNotifications.existingSecret ) }}
   PUSH_INSTALLATION_ID: {{ .Values.pushNotifications.installationId.value | b64enc | quote }}
   PUSH_INSTALLATION_KEY: {{ .Values.pushNotifications.installationKey.value | b64enc | quote }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -772,3 +772,70 @@ ingress:
   ##   - Add support for using cert-manager.
   ##   - Support for multiple TLS hostnames.
   ##
+
+## @section SSO OpenID Connect Configuration support for https://github.com/dani-garcia/vaultwarden/pull/3899
+##
+sso:
+  ## @param sso.enabled boolean to define if SSO is enabled or not.
+  ##
+  enabled: false
+  ## @param sso.existingSecret Name of an existing secret containing the OpenID Connect client id and secret. Also set sso.clientId.existingSecretKey and sso.clientSecret.existingSecretKey.
+  ##
+  existingSecret: ""
+  ## @param sso.onlySSO boolen to disable the email+master-password login flow.
+  ##
+  onlySSO: false
+  ## @param sso.enforceSSO boolen to enforce SSO authentication for all users (except admin token access).
+  ##
+  enforceSSO: false
+  ## @param sso.signupsMatchEmail boolen to define if SSO user signup should take control of existing account with given mail (only works during signup).
+  signupsMatchEmail: true
+  ## @param sso.ignoreEmailVerification boolean to define if signup without mail verification is allowed (this is needed if your SSO provider does not send the 'email_verified' claim).
+  ##
+  ignoreEmailVerification: false
+  ## @param sso.authority the OpenID Connect Discovery endpoint without '/.well-known/openid-configuration' and trailing '/'-
+  ## Example: https://account.example.com/realm/example
+  ##
+  authority: ""
+  ## @param sso.scopes OpenID connect scopes to use
+  ##
+  scopes: "email profile"
+  ## @param sso.authorizeExtraParams OpenID connect extra params fort he authorize redirect.
+  ##
+  authorizeExtraParams: ""
+  ## @param sso.pkce boolean to enable/disable PKCE for the auth flow
+  ##
+  pkce: true
+  ## @param sso.trustedAudience additional audience to trust for the ID token. (`client_id` is always trusted). Use single quote when writing the regex: `'^$'`.
+  ##
+  trustedAudience: ''
+  ## @param sso.masterPasswordPolicy optional master password policy for sso (currently 'enforceOnLogin' is not supported).
+  ##
+  masterPasswordPolicy: '{"enforceOnLogin":false,"minComplexity":3,"minLength":12,"requireLower":true,"requireNumbers":true,"requireSpecial":true,"requireUpper":true}'
+  ## @param sso.disableSessionHandling optional boolean to disable sso session handling  if you can not retrieve refresh_tokens (access token will have default lifetime form 2h and refresh token from 7 days)
+  ##
+  disableSessionHandling: false
+  ## @param sso.cacheExpiration expiration time for sso client cache, passing 0 disables the cache.
+  ##
+  cacheExpiration: 0
+  ## @param sso.debugTokens boolen to enbable token logging for debugging purpose
+  ##
+  debugTokens: false
+  ## Client ID for OpenID Connect authentication.
+  ##
+  clientId:
+    ## @param sso.clientId.value string for the client id of the OpenID Connect authentication.
+    ##
+    value: ""
+    ## @param sso.clientId.existingSecretKey When using an existing secret, specify the key which contains the password.
+    ##
+    existingSecretKey: ""
+  ## Client ID for OpenID Connect authentication.
+  ##
+  clientSecret:
+    ## @param sso.clientSecret.value string for the client id of the OpenID Connect authentication.
+    ##
+    value: ""
+    ## @param sso.clientSecret.existingSecretKey When using an existing secret, specify the key which contains the password.
+    ##
+    existingSecretKey: ""

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -839,3 +839,37 @@ sso:
     ## @param sso.clientSecret.existingSecretKey When using an existing secret, specify the key which contains the password.
     ##
     existingSecretKey: ""
+  ## Client Roles for OpenID Connect authentication. (Only works with the release build from https://github.com/Timshel/vaultwarden as we await a PR)
+  ##
+  roles:
+    ## @param sso.roles.enabled boolean to enable/disable role mapping from ID token claim (supports currently role "admin" and "user")
+    ##
+    enabled: false
+    ## @param sso.roles.defaultToUser boolen to assign user role as fallback if no role claim was found. (users without a "user" role can't login).
+    ##
+    defaultToUser: true
+    ## @param sso.roles.tokenPath is used to specify the path to the roles claim inside the ID token.
+    ##
+    tokenPath: ""
+  ## Organisation invite for OpenID Connect authentication.
+  ##
+  organizations:
+    ## @param sso.organizations.enabled boolean to enable/disable automatic organization mapping for SSO users. (Only works with the release build from https://github.com/Timshel/vaultwarden as we await a PR)
+    ##
+    enabled: false
+    ## @param sso.organizations.inviteAll boolean to enable/disable automatic invitation to all organizations in vaultwarden. 
+    ##
+    inviteAll: false
+    ## @param sso.organizations.inviteAutoAccept boolean to enable/disable automatic acceptance of organization invites. 
+    ## ATTENTION: This will apply to non SSO users as well and organization acceptance will considered by default !!! 
+    ##
+    inviteAutoAccept: false
+    ## @param sso.organizations.enableRevocation boolen to control if user membership from organizations can be revoked by IDP
+    ##
+    enableRevocation: false
+    ## @param sso.organizations.tokenPath is used to specify the path to the groups claim inside the ID token.
+    ##
+    tokenPath: ""
+    ## @param sso.organizations.mappings is used to map IDP group id's to vaultwarden group id's. (format: "ProviderId:VaultwardenId;", seperated by ";")
+    ##
+    mappings: ""


### PR DESCRIPTION
As SSO to Vaultwarden using OpenID Connect will be soon available via the PR https://github.com/dani-garcia/vaultwarden/pull/3899, it would be nice to control this with the recommended helm chart of vaultwarden. Therefore this PR adds the newly added parameters to the chart and enables SSO configuration.

The PR is already combining the settings from the original PR as well as the additions which @Timshell is nicely maintaining here https://github.com/Timshel/vaultwarden until the initial PR was merged.