### PR TITLE
fix: change postgresql port to 5432 in README examples

### DIFF
--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -72,13 +72,13 @@ You can also specify the connection string:
 ```yaml
 database:
   type: postgresql
-  uriOverride: "postgresql://appuser:apppassword@pg.contoso.eu:5433/qualdb"
+  uriOverride: "postgresql://appuser:apppassword@pg.contoso.eu:5432/qualdb"
 ```
 
 Alternatively, you could create a Kubernetes secret containing the database URI:
 
 ```bash
-DB_STRING="postgresql://appuser:apppassword@pg.contoso.eu:5433/qualdb"
+DB_STRING="postgresql://appuser:apppassword@pg.contoso.eu:5432/qualdb"
 kubectl -n vaultwarden create secret generic prod-db-creds --from-literal=secret-uri=$DB_STRING
 ```
 


### PR DESCRIPTION
The postgresql examples were using port `5433` instead of the postgresql default port `5432`, which can lead users unfamiliar with postgresql and into deep rabbit holes.
Especially since the secret creation examples obfuscates the value of the uri with base64.

Ask me how I know 🤪 