### PR TITLE
Add extra env vars from ConfigMap or Secret

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.31.8
+version: 0.32.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -354,6 +354,8 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `image.pullSecrets`     | Specify docker-registry secrets                                                           | `[]`                 |
 | `image.extraSecrets`    | Vaultwarden image extra secrets                                                           | `[]`                 |
 | `image.extraVars`       | Vaultwarden image extra vars                                                              | `[]`                 |
+| `image.extraVarsCM`     | Vaultwarden image extra vars ConfigMap                                                    | `""`                 |
+| `image.extraVarsSecret` | Vaultwarden image extra vars Secret                                                       | `""`                 |
 | `replicas`              | Number of deployment replicas                                                             | `1`                  |
 | `fullnameOverride`      | String to override the application name.                                                  | `""`                 |
 | `resourceType`          | Can be either Deployment or StatefulSet                                                   | `""`                 |

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -33,6 +33,14 @@ containers:
     envFrom:
       - configMapRef:
           name: {{ include "vaultwarden.fullname" . }}
+      {{- if .Values.image.extraVarsCM }}
+      - configMapRef:
+          name: {{ .Values.image.extraVarsCM }}
+      {{- end }}
+      {{- if .Values.image.extraVarsSecret }}
+      - secretRef:
+          name: {{ .Values.image.extraVarsSecret }}
+      {{- end }}
     env:
       {{- range .Values.image.extraVars }}
       - name: {{ .key }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -39,6 +39,14 @@ image:
   ##     value: https://bananaguy.com/auth
   ##
   extraVars: []
+  ## @param image.extraVarsCM Vaultwarden image extra vars ConfigMap
+  ## Example:
+  ## extraVarsCM: "vaultwarden-extra-vars"
+  extraVarsCM: ""
+  ## @param image.extraVarsSecret Vaultwarden image extra vars Secret
+  ## Example:
+  ## extraVarsSecret: "vaultwarden-extra-vars"
+  extraVarsSecret: ""
 
 ## @param replicas Number of deployment replicas
 ##


### PR DESCRIPTION
I am currently using this helm chart in combination with the image from [Timshel/OIDCWarden](https://github.com/Timshel/OIDCWarden).
However, since that image requires that several environment variables, some of which are confidential like `SSO_CLIENT_SECRET`, are set, I would like to outsource them so that they are not in plain text in the values file.

As long as #153 has not yet been merged, this one provides a solution