### PR TITLE
Remove configuration for data.attachments as it doesn't do anything

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.34.4
+version: 1.0.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -300,10 +300,14 @@ Vaultwarden requires persistent storage for its attachments and icons cache.
 
 To use persistent storage using a claim, set the `storage.data` dictionary. Optionally set a different path using the `path` key. The following example sets the storage class to an already-installed Rancher's [local path storage](https://github.com/rancher/local-path-provisioner) provisioner.
 
+> [!NOTE]
+> If you change the `path` of mounted data, be sure to update the `DATA_FOLDER`
+> environment variable to match (via the `extraVars` values param).
+
 ```yaml
 data:
   name: "vaultwarden-data"
-  size: "15Gi"
+  size: "100Gi"
   class: "local-path"
 ```
 
@@ -312,41 +316,22 @@ Example for AWS:
 ```yaml
 data:
   name: "vaultwarden-data"
-  size: "10Gi"
+  size: "100Gi"
   class: "gp2"
   path: "/srv/vaultwarden-data"
-```
-
-To use persistent storage for attachments, set the `storage.attachments` dictionary. Optionally set a different path. Note that by default, the path is `/data/attachments`.
-
-```yaml
-attachments:
-  name: "vaultwarden-data"
-  size: "15Gi"
-  class: "local-path"
 ```
 
 In case you want to keep the existing persistent volume claim during uninstall and redeployments, set the option `keepPvc: true`
 (This will be ignored for StatefulSets and is only relevant for `resourceType: Deployment`)
 
-```yaml
-attachments:
-  name: "vaultwarden-data"
-  size: "15Gi"
-  class: "local-path"
-  keepPvc: true
-```
-
 ### Using an Existing Persistent Volume Claim
 
-In case you want to use an existing PVC to store your data and attachments (i.e. NAS), `storage.existingVolumeClaim` can be set, which will update the PodSpec to use the provided PVC.  Note, that use of this value will ignore the values of both `storage.data` 
-and `storage.attachments` values.
+In case you want to use an existing PVC to store your data and attachments (i.e. NAS), `storage.existingVolumeClaim` can be set, which will update the PodSpec to use the provided PVC.  Note, that use of this value will ignore the value of `storage.data`.
 
 ```yaml
 existingVolumeClaim:
     claimName: "vaultwarden-pvc"
     dataPath: "/data"
-    attachmentsPath: /data/attachments
 ```
 
 ## Uninstall
@@ -436,7 +421,6 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | ----------------------------- | ------------------------------------------------------------------------- | ------ |
 | `storage.existingVolumeClaim` | If defined, the values here will be used for the data and                 | `{}`   |
 | `storage.data`                | Data directory configuration, refer to values.yaml for parameters.        | `{}`   |
-| `storage.attachments`         | Attachments directory configuration, refer to values.yaml for parameters. | `{}`   |
 | `webVaultEnabled`             | Enable Web Vault                                                          | `true` |
 
 ### Database settings

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -162,19 +162,13 @@ containers:
     {{- with .Values.storage.existingVolumeClaim }}
       - name: vaultwarden-data
         mountPath: {{ default "/data" .dataPath }}
-      - name: vaultwarden-data
-        mountPath: {{ default "/data/attachments" .attachmentsPath }}
     {{- end }}
     {{- else }}
-    {{- if or (.Values.storage.data) (.Values.storage.attachments) }}
+    {{- if or (.Values.storage.data) }}
     volumeMounts:
       {{- with .Values.storage.data }}
       - name: {{ .name }}
         mountPath: {{ default "/data" .path }}
-      {{- end }}
-      {{- with .Values.storage.attachments }}
-      - name: {{ .name }}
-        mountPath: {{ default "/data/attachments" .path }}
       {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -286,15 +286,13 @@ podDisruptionBudget:
 
 
 storage:
-  ## @param storage.existingVolumeClaim If defined, the values here will be used for the data and
-  ## attachments PV's. The custom values for data and attachments will be ignored if
-  ## a value is set here
+  ## @param storage.existingVolumeClaim If defined, the values here will be used for the data PV.
+  ## The custom values for `data` be ignored if a value is set for `existingVolumeClaim`
   ##
   existingVolumeClaim:
     {}
     # claimName: "vaultwarden-pvc"
     # dataPath: "/data"
-    # attachmentsPath: /data/attachments
 
   ## @param storage.data Data directory configuration, refer to values.yaml for parameters.
   ##
@@ -304,18 +302,6 @@ storage:
     # size: "15Gi"
     # class: ""
     # path: "/data"
-    # keepPvc: false
-    # accessMode: "ReadWriteOnce"
-
-  ## @param storage.attachments Attachments directory configuration, refer to values.yaml for parameters.
-  ## By default, attachments/ is located inside the data directory.
-  ##
-  attachments:
-    {}
-    # name: "vaultwarden-files"
-    # size: "100Gi"
-    # class: ""
-    # path: /files
     # keepPvc: false
     # accessMode: "ReadWriteOnce"
 


### PR DESCRIPTION
Follow on from https://github.com/guerzon/vaultwarden/pull/178

- Includes a possible breaking change - info should be included in the release notes.
- Removes `data.attachments`, as the server has no way to split out data / attachments into separate dirs.
- Updated any docs referencing this.
- Increment chart to v1.0.0, as it's probably well tested by now and ready for full release too!