### PR TITLE
sso.disableSessionHandling not linked to configmap

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.35.1
+version: 0.35.2
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -135,7 +135,7 @@ data:
   {{- if .Values.sso.masterPasswordPolicy }}
   SSO_MASTER_PASSWORD_POLICY: {{ .Values.sso.masterPasswordPolicy | quote }}
   {{- end }}
-  SSO_AUTH_ONLY_NOT_SESSION: {{ .Values.sso.authOnly | quote }}
+  SSO_AUTH_ONLY_NOT_SESSION: {{ .Values.sso.disableSessionHandling | quote }}
   SSO_CLIENT_CACHE_EXPIRATION: {{ .Values.sso.cacheExpiration | quote }}
   SSO_DEBUG_TOKENS: {{ .Values.sso.debugTokens | quote }}
   {{- if .Values.sso.enforceSSO }}


### PR DESCRIPTION
`sso.disableSessionHandling` was not linked to the configmap, since the env variable `SSO_AUTH_ONLY_NOT_SESSION` is defined by the value `sso.authOnly` which does not exist.

From the [official documentation](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-SSO-support-using-OpenId-Connect#disabling-sso-session-handling) :

> Disabling SSO session handling
> If you are unable to obtain a refresh_token or for any other reason you can disable SSO session handling and revert to the default handling. You'll need to enable SSO_AUTH_ONLY_NOT_SESSION=true then access token will be valid for 2h and refresh token will allow for an idle time of 7 days (which can be indefinitely extended).