### PR TITLE
Add annotation support for storage PVCs

### DIFF
--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -337,6 +337,27 @@ attachments:
   keepPvc: true
 ```
 
+
+You can add additional annotations to the `data` and `attachments` PVCs using the `annotations` key. These will be directly injected so ensure they values are all strings.
+
+
+```yaml
+data:
+  name: "vaultwarden-data"
+  size: "15Gi"
+  class: "local-path"
+  annotations:
+    example.com/additional-annotation: 'true'
+
+attachments:
+  name: "vaultwarden-attachments"
+  size: "15Gi"
+  class: "local-path"
+  annotations:
+    example.com/additional-annotation: 'true'
+```
+
+
 ### Using an Existing Persistent Volume Claim
 
 In case you want to use an existing PVC to store your data and attachments (i.e. NAS), `storage.existingVolumeClaim` can be set, which will update the PodSpec to use the provided PVC.  Note, that use of this value will ignore the values of both `storage.data` 

--- a/charts/vaultwarden/templates/_pvcSpec.tpl
+++ b/charts/vaultwarden/templates/_pvcSpec.tpl
@@ -14,6 +14,9 @@ volumeClaimTemplates:
         {{- if .keepPvc }}
         helm.sh/resource-policy: keep
         {{- end }}
+        {{- with .annotations }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       accessModes:
         - {{ .accessMode | quote }}
@@ -36,6 +39,9 @@ volumeClaimTemplates:
         meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}
         {{- if .keepPvc }}
         helm.sh/resource-policy: keep
+        {{- end }}
+        {{- with .annotations }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
     spec:
       accessModes:

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -306,6 +306,7 @@ storage:
     # path: "/data"
     # keepPvc: false
     # accessMode: "ReadWriteOnce"
+    # annotations: {}
 
   ## @param storage.attachments Attachments directory configuration, refer to values.yaml for parameters.
   ## By default, attachments/ is located inside the data directory.
@@ -318,6 +319,7 @@ storage:
     # path: /files
     # keepPvc: false
     # accessMode: "ReadWriteOnce"
+    # annotations: {}
 
 ## @param webVaultEnabled Enable Web Vault
 ##


### PR DESCRIPTION
Add support for arbitrary annotations on the storage PVCs. This will allow for using k8up for backups.