### PR TITLE
fix: Rename disableSessionHandling to authOnly in values.yaml

### DIFF
--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -854,9 +854,9 @@ sso:
   ## @param sso.masterPasswordPolicy optional master password policy for sso (currently 'enforceOnLogin' is not supported).
   ##
   masterPasswordPolicy: '{"enforceOnLogin":false,"minComplexity":3,"minLength":12,"requireLower":true,"requireNumbers":true,"requireSpecial":true,"requireUpper":true}'
-  ## @param sso.disableSessionHandling optional boolean to disable sso session handling  if you can not retrieve refresh_tokens (access token will have default lifetime form 2h and refresh token from 7 days)
+  ## @param sso.authOnly optional boolean to disable sso session handling  if you can not retrieve refresh_tokens (access token will have default lifetime form 2h and refresh token from 7 days)
   ##
-  disableSessionHandling: false
+  authOnly: false
   ## @param sso.cacheExpiration expiration time for sso client cache, passing 0 disables the cache.
   ##
   cacheExpiration: 0


### PR DESCRIPTION
The vaultwarden configmap is already generated with the defined value of the `sso.authOnly` variable from the values file.

`SSO_AUTH_ONLY_NOT_SESSION` will get the value which is defined in the `values.yaml`

```
SSO_AUTH_ONLY_NOT_SESSION: {{ .Values.sso.authOnly | quote }}
```

xref: https://github.com/guerzon/vaultwarden/blob/main/charts/vaultwarden/templates/configmap.yaml#L138

This also replaces PR https://github.com/guerzon/vaultwarden/pull/198.

> Note:
Everyone who stumbles over this and the change isn't merged and released yet:
As we do not have a schema for the values file, it's fine to just replace `disableSessionHandling` with `authOnly` in your values file. This PR is mainly to fix the gap in the documented `values.yaml` and help users to safe some time during troubleshooting :sweat_smile: 