### PR TITLE
fix: skip DOMAIN env var when empty for multi-domain support

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.36.1
+version: 0.36.2
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -20,7 +20,9 @@ metadata:
     {{- . | toYaml | nindent 4 }}
 {{- end }}
 data:
+  {{- if .Values.domain }}
   DOMAIN: {{ .Values.domain | quote }}
+  {{- end }}
   {{- if and .Values.smtp.host .Values.smtp.from }}
   SMTP_HOST: {{ .Values.smtp.host | quote }}
   SMTP_SECURITY: {{ .Values.smtp.security | quote }}


### PR DESCRIPTION
Currently, setting `domain: ""` renders `DOMAIN: ""` in the ConfigMap, which causes Vaultwarden to fail on startup with:

```
Error validating domain: relative URL without a base
```

Vaultwarden uses `is_some()` to check whether DOMAIN is set — an empty string is still considered "set", so it never enters the multi-domain fallback path that reads Host/X-Forwarded-Host headers dynamically.

By omitting the DOMAIN key entirely when empty, Vaultwarden treats it as unset, enabling multi-domain access through a single deployment.