### PR TITLE
feat: support HTTPS in Vaultwarden service using Rocket

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: lester@guerzon.net
     url: https://github.com/guerzon
-version: 0.41.0
+version: 0.42.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -71,7 +71,7 @@ containers:
           secretKeyRef:
             name: {{ default (include "vaultwarden.fullname" .) .Values.duo.existingSecret }}
             key: {{ default "DUO_SKEY" .Values.duo.sKey.existingSecretKey }}
-      {{- end }}  
+      {{- end }}
       {{- if or (.Values.smtp.username.value) (.Values.smtp.username.existingSecretKey )}}
       - name: SMTP_USERNAME
         valueFrom:
@@ -177,7 +177,7 @@ containers:
       - containerPort: {{ .Values.rocket.port }}
         name: http
         protocol: TCP
-    {{- if or (.Values.storage.existingVolumeClaim) (.Values.storage.data) (.Values.storage.attachments) (.Values.extraVolumeMounts) }}
+    {{- if or (.Values.storage.existingVolumeClaim) (.Values.storage.data) (.Values.storage.attachments) (.Values.rocket.tls.secretName) (.Values.extraVolumeMounts) }}
     volumeMounts:
     {{- end }}
     {{- if .Values.storage.existingVolumeClaim }}
@@ -197,6 +197,10 @@ containers:
       {{- end }}
     {{- end }}
     {{- end }}
+    {{- if .Values.rocket.tls.secretName }}
+      - name: vaultwarden-tls
+        mountPath: {{ .Values.rocket.tls.path }}
+    {{- end }}
     {{- with .Values.extraVolumeMounts }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
@@ -211,6 +215,11 @@ containers:
       httpGet:
         path: {{ .Values.livenessProbe.path }}
         port: http
+        {{- if .Values.rocket.tls.secretName }}
+        scheme: HTTPS
+        {{- else }}
+        scheme: HTTP
+        {{- end }}
       initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
       periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
       timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -222,6 +231,11 @@ containers:
       httpGet:
         path: {{ .Values.readinessProbe.path }}
         port: http
+        {{- if .Values.rocket.tls.secretName }}
+        scheme: HTTPS
+        {{- else }}
+        scheme: HTTP
+        {{- end }}
       initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
       periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
       timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -71,7 +71,7 @@ containers:
           secretKeyRef:
             name: {{ default (include "vaultwarden.fullname" .) .Values.duo.existingSecret }}
             key: {{ default "DUO_SKEY" .Values.duo.sKey.existingSecretKey }}
-      {{- end }}  
+      {{- end }}
       {{- if or (.Values.smtp.username.value) (.Values.smtp.username.existingSecretKey )}}
       - name: SMTP_USERNAME
         valueFrom:
@@ -168,7 +168,7 @@ containers:
       - containerPort: 8080
         name: http
         protocol: TCP
-    {{- if or (.Values.storage.existingVolumeClaim) (.Values.storage.data) (.Values.storage.attachments) (.Values.extraVolumeMounts) }}
+    {{- if or (.Values.storage.existingVolumeClaim) (.Values.storage.data) (.Values.storage.attachments) (.Values.rocket.tls.secretName) (.Values.extraVolumeMounts) }}
     volumeMounts:
     {{- end }}
     {{- if .Values.storage.existingVolumeClaim }}
@@ -188,6 +188,10 @@ containers:
       {{- end }}
     {{- end }}
     {{- end }}
+    {{- if .Values.rocket.tls.secretName }}
+      - name: vaultwarden-tls
+        mountPath: {{ .Values.rocket.tls.path }}
+    {{- end }}
     {{- with .Values.extraVolumeMounts }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
@@ -202,6 +206,11 @@ containers:
       httpGet:
         path: {{ .Values.livenessProbe.path }}
         port: http
+        {{- if .Values.rocket.tls.secretName }}
+        scheme: HTTPS
+        {{- else }}
+        scheme: HTTP
+        {{- end }}
       initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
       periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
       timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -213,6 +222,11 @@ containers:
       httpGet:
         path: {{ .Values.readinessProbe.path }}
         port: http
+        {{- if .Values.rocket.tls.secretName }}
+        scheme: HTTPS
+        {{- else }}
+        scheme: HTTP
+        {{- end }}
       initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
       periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
       timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -233,6 +247,12 @@ containers:
     {{- with .Values.sidecars }}
     {{- toYaml . | nindent 2 }}
     {{- end }}
+{{- if .Values.rocket.tls.secretName }}
+volumes:
+  - name: vaultwarden-tls
+    secret:
+      secretName: {{ .Values.rocket.tls.secretName }}
+{{- end }}
 {{- if .Values.serviceAccount.create }}
 serviceAccountName: {{ .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -45,6 +45,11 @@ data:
   ROCKET_ADDRESS: {{ .Values.rocket.address | quote }}
   ROCKET_PORT: {{ .Values.rocket.port | quote }}
   ROCKET_WORKERS: {{ .Values.rocket.workers | quote }}
+  {{- if .Values.rocket.tls.secretName }}
+  {{- with .Values.rocket.tls }}
+  ROCKET_TLS: '{certs="{{ .path }}/{{ .keyTLSCert }}",key="{{ .path }}/{{ .keyTLSKey }}"}'
+  {{- end }}
+  {{- end }}
   SHOW_PASSWORD_HINT: {{ .Values.showPassHint | quote }}
   SIGNUPS_ALLOWED: {{ .Values.signupsAllowed | quote }}
   INVITATIONS_ALLOWED: {{ .Values.invitationsAllowed | quote }}

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -48,6 +48,11 @@ data:
   ROCKET_ADDRESS: {{ .Values.rocket.address | quote }}
   ROCKET_PORT: {{ .Values.rocket.port | quote }}
   ROCKET_WORKERS: {{ .Values.rocket.workers | quote }}
+  {{- if .Values.rocket.tls.secretName }}
+  {{- with .Values.rocket.tls }}
+  ROCKET_TLS: '{certs="{{ .path }}/tls.crt",key="{{ .path }}/tls.key"}'
+  {{- end }}
+  {{- end }}
   SHOW_PASSWORD_HINT: {{ .Values.showPassHint | quote }}
   SIGNUPS_ALLOWED: {{ .Values.signupsAllowed | quote }}
   INVITATIONS_ALLOWED: {{ .Values.invitationsAllowed | quote }}

--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- end }}
     spec:
       {{- include "vaultwarden.podSpec" . | nindent 6 }}
-      {{- if or (.Values.storage.existingVolumeClaim) (.Values.storage.data) (.Values.storage.attachments) (.Values.extraVolumes) }}
+      {{- if or (.Values.storage.existingVolumeClaim) (.Values.storage.data) (.Values.storage.attachments) (.Values.rocket.tls.secretName) (.Values.extraVolumes) }}
       volumes:
         {{- if .Values.storage.existingVolumeClaim }}
         {{- with .Values.storage.existingVolumeClaim }}
@@ -55,6 +55,11 @@ spec:
           persistentVolumeClaim:
             claimName: {{ $newName }}
         {{- end }}
+        {{- end }}
+        {{- if .Values.rocket.tls.secretName }}
+        - name: vaultwarden-tls
+          secret:
+            secretName: {{ .Values.rocket.tls.secretName }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -64,7 +64,11 @@ spec:
             service:
               name: {{ include "vaultwarden.fullname" $ }}
               port:
+                {{- if .Values.rocket.tls.secretName }}
+                name: "https"
+                {{- else }}
                 name: "http"
+                {{- end }}
     {{- end }}
     - host: {{ $ingress.hostname | quote }}
       http:
@@ -75,5 +79,9 @@ spec:
             service:
               name: {{ include "vaultwarden.fullname" . }}
               port:
+                {{- if .Values.rocket.tls.secretName }}
+                name: "https"
+                {{- else }}
                 name: "http"
+                {{- end }}
 {{- end }}

--- a/charts/vaultwarden/templates/service.yaml
+++ b/charts/vaultwarden/templates/service.yaml
@@ -19,10 +19,17 @@ spec:
     app.kubernetes.io/component: vaultwarden
     {{- include "vaultwarden.selectorLabels" . | nindent 4 }}
   ports:
+{{- if .Values.rocket.tls.secretName }}
+    - name: "https"
+      port: 443
+      protocol: TCP
+      targetPort: 8080
+{{- else }}
     - name: "http"
       port: 80
       protocol: TCP
       targetPort: 8080
+{{- end }}
 {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
 {{- end }}

--- a/charts/vaultwarden/templates/service.yaml
+++ b/charts/vaultwarden/templates/service.yaml
@@ -19,8 +19,13 @@ spec:
     app.kubernetes.io/component: vaultwarden
     {{- include "vaultwarden.selectorLabels" . | nindent 4 }}
   ports:
+{{- if .Values.rocket.tls.secretName }}
+    - name: "https"
+      port: 443
+{{- else }}
     - name: "http"
       port: 80
+{{- end }}
       protocol: TCP
       targetPort: {{ .Values.rocket.port }}
 {{- if .Values.service.ipFamilyPolicy }}

--- a/charts/vaultwarden/templates/statefulset.yaml
+++ b/charts/vaultwarden/templates/statefulset.yaml
@@ -41,12 +41,17 @@ spec:
         {{- end }}
     spec:
       {{- include "vaultwarden.podSpec" . | nindent 6 }}
-      {{- if or (.Values.storage.existingVolumeClaim) (.Values.extraVolumes) }}
+      {{- if or (.Values.storage.existingVolumeClaim) (.Values.rocket.tls.secretName) (.Values.extraVolumes) }}
       volumes:
         {{- with .Values.storage.existingVolumeClaim }}
         - name: vaultwarden-data
           persistentVolumeClaim:
             claimName: {{ .claimName }}
+        {{- end }}
+        {{- if .Values.rocket.tls.secretName }}
+        - name: vaultwarden-tls
+          secret:
+            secretName: {{ .Values.rocket.tls.secretName }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -736,6 +736,21 @@ rocket:
   address: "0.0.0.0"
   port: "8080"
   workers: "10"
+  tls:
+    ## @param rocket.tls.secretName Name of the secret with TLS key and certificate
+    ## If unset, Vaultwarden service listens to HTTP. If set, specified certificate
+    ## is used for HTTPS.
+    ##
+    secretName: ""
+    ## @param rocket.tls.secretName Key of the TLS key within the secret
+    ##
+    keyTLSKey: "tls.key"
+    ## @param rocket.tls.secretName Key of the TLS certificate within the secret
+    ##
+    keyTLSCert: "tls.crt"
+    ## @param rocket.tls.path Path to mount TLS secrets within the container
+    ##
+    path: "/certs"
 
 ## Service configuration
 service:

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -765,6 +765,14 @@ rocket:
   address: "0.0.0.0"
   port: "8080"
   workers: "10"
+  tls:
+    ## @param rocket.tls.secretName Name of the kubernetes.io/tls secret to use for HTTPS.
+    ## If unset, Vaultwarden service listens to HTTP.
+    ##
+    secretName: ""
+    ## @param rocket.tls.path Path to mount TLS secrets within the container
+    ##
+    path: "/certs"
 
 ## Service configuration
 service:


### PR DESCRIPTION
Support passing TLS certificate to Vaultwarden service using Rocket TLS support (without ingress).

If `rocket.tls.secretName` is defined in the `values.yaml` , the secret with the TLS key and certificate is mounted to the container (by default to `/certs` folder) and certificate from this secret is used for the Vaultwarden service. Service itself starts listening on the port 443 in this case.

My personal motivation for that is that I want to use Netbird Kubernetes operator to expose the service (bypassing Ingress), but still have HTTPS. That way I can get a certificate using LetsEncrypt and use it with Vaultwarden.

Closes #68 