### PR TITLE
Bump 1.36.0

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -8,10 +8,10 @@ keywords:
 sources:
   - https://github.com/guerzon/vaultwarden
   - https://github.com/dani-garcia/vaultwarden
-appVersion: 1.35.8
+appVersion: 1.36.0
 maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.36.3
+version: 0.36.4
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -8,10 +8,10 @@ keywords:
 sources:
   - https://github.com/guerzon/vaultwarden
   - https://github.com/dani-garcia/vaultwarden
-appVersion: 1.35.7
+appVersion: 1.35.8
 maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.36.2
+version: 0.36.3
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -368,7 +368,7 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | ----------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`        | Vaultwarden image registry                                                                | `docker.io`          |
 | `image.repository`      | Vaultwarden image repository                                                              | `vaultwarden/server` |
-| `image.tag`             | Vaultwarden image tag                                                                     | `1.35.7-alpine`      |
+| `image.tag`             | Vaultwarden image tag                                                                     | `1.35.8-alpine`      |
 | `image.pullPolicy`      | Vaultwarden image pull policy                                                             | `IfNotPresent`       |
 | `image.pullSecrets`     | Specify docker-registry secrets                                                           | `[]`                 |
 | `image.extraSecrets`    | Vaultwarden image extra secrets                                                           | `[]`                 |

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -368,7 +368,7 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | ----------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`        | Vaultwarden image registry                                                                | `docker.io`          |
 | `image.repository`      | Vaultwarden image repository                                                              | `vaultwarden/server` |
-| `image.tag`             | Vaultwarden image tag                                                                     | `1.35.8-alpine`      |
+| `image.tag`             | Vaultwarden image tag                                                                     | `1.36.0-alpine`      |
 | `image.pullPolicy`      | Vaultwarden image pull policy                                                             | `IfNotPresent`       |
 | `image.pullSecrets`     | Specify docker-registry secrets                                                           | `[]`                 |
 | `image.extraSecrets`    | Vaultwarden image extra secrets                                                           | `[]`                 |

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -13,7 +13,7 @@ image:
   ## @param image.tag Vaultwarden image tag
   ## Ref: https://hub.docker.com/r/vaultwarden/server/tags
   ##
-  tag: "1.35.7-alpine"
+  tag: "1.35.8-alpine"
   ## @param image.pullPolicy Vaultwarden image pull policy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -13,7 +13,7 @@ image:
   ## @param image.tag Vaultwarden image tag
   ## Ref: https://hub.docker.com/r/vaultwarden/server/tags
   ##
-  tag: "1.35.8-alpine"
+  tag: "1.36.0-alpine"
   ## @param image.pullPolicy Vaultwarden image pull policy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
[1.36.0](https://github.com/dani-garcia/vaultwarden/releases/tag/1.36.0)

Repository: [dani-garcia/vaultwarden](https://github.com/dani-garcia/vaultwarden) · Tag: [1.36.0](https://github.com/dani-garcia/vaultwarden/tree/1.36.0) · Commit: [f21a3ad](https://github.com/dani-garcia/vaultwarden/commit/f21a3adae2fbb8582b60b121783c597fe6895ff4) · Released by: [BlackDex](https://github.com/BlackDex)

Security Fixes

This release contains security fixes for the following advisories. We strongly advice to update as soon as possible.

SSO Login CSRF
[GHSA-pfp2-jhgq-6hg5](https://github.com/dani-garcia/vaultwarden/security/advisories/GHSA-pfp2-jhgq-6hg5)
[GHSA-w6h6-8r66-hcv7](https://github.com/dani-garcia/vaultwarden/security/advisories/GHSA-w6h6-8r66-hcv7)
User/Organization Enumeration
[GHSA-hxqh-ff5p-wfr3](https://github.com/dani-garcia/vaultwarden/security/advisories/GHSA-hxqh-ff5p-wfr3)
SSO existing-user binding
[GHSA-j4j8-gpvj-7fqr](https://github.com/dani-garcia/vaultwarden/security/advisories/GHSA-j4j8-gpvj-7fqr)
[GHSA-6x5c-84vm-5j56](https://github.com/dani-garcia/vaultwarden/security/advisories/GHSA-6x5c-84vm-5j56)
SSRF via Icon Endpoint
[GHSA-72vh-x5jq-m82g](https://github.com/dani-garcia/vaultwarden/security/advisories/GHSA-72vh-x5jq-m82g)
Some crate's updated and other minor security enhancements
These are private for now, pending CVE assignment.

Notes

Archiving of items is available
https://bitwarden.com/blog/keep-your-vault-tidy-with-item-archiving/
https://bitwarden.com/nl-nl/help/managing-items/#archive
Web Vault updated to v2026.4.1
What's Changed

SSO fallback to UserInfo preferred_username by @Timshel in https://github.com/dani-garcia/vaultwarden/pull/7128
Dummy identifier need to pass for a guid by @Timshel in https://github.com/dani-garcia/vaultwarden/pull/7154
add new /identity/accounts/prelogin/password by @stefan0xC in https://github.com/dani-garcia/vaultwarden/pull/7156
Add DuckDuckGo browser device type by @dfunkt in https://github.com/dani-garcia/vaultwarden/pull/7147
Apply duration_suboptimal_units lint findings by @dfunkt in https://github.com/dani-garcia/vaultwarden/pull/7144
Apply ref_option lint findings by @dfunkt in https://github.com/dani-garcia/vaultwarden/pull/7143
Fix hardcoded sso identifier by @Timshel in https://github.com/dani-garcia/vaultwarden/pull/7157
Update crates and fix a nightly lint by @BlackDex in https://github.com/dani-garcia/vaultwarden/pull/7161
Fix Host/IP resolving by @BlackDex in https://github.com/dani-garcia/vaultwarden/pull/7162
Several SSO Fixes by @BlackDex in https://github.com/dani-garcia/vaultwarden/pull/7163
Add support for archiving items by @matt-aaron in https://github.com/dani-garcia/vaultwarden/pull/6916
Fix favicon fetching to check all icon links instead of just the first one by @Shocker in https://github.com/dani-garcia/vaultwarden/pull/6880
Fix merge conflict by @dani-garcia in https://github.com/dani-garcia/vaultwarden/pull/7164
Replace organization_uuid unwrap with proper error handling by @xjohnyknox in https://github.com/dani-garcia/vaultwarden/pull/6936
fix: return Err instead of panic on unknown cipher atype in to_json() by @mango766 in https://github.com/dani-garcia/vaultwarden/pull/7068
Allow SQLite to be linked against dynamically by @ISSOtm in https://github.com/dani-garcia/vaultwarden/pull/7057
Update crates and web-vault by @BlackDex in https://github.com/dani-garcia/vaultwarden/pull/7171
Update hickory by @BlackDex in https://github.com/dani-garcia/vaultwarden/pull/7175
New Contributors

@matt-aaron made their first contribution in https://github.com/dani-garcia/vaultwarden/pull/6916
@Shocker made their first contribution in https://github.com/dani-garcia/vaultwarden/pull/6880
@xjohnyknox made their first contribution in https://github.com/dani-garcia/vaultwarden/pull/6936
@mango766 made their first contribution in https://github.com/dani-garcia/vaultwarden/pull/7068
@ISSOtm made their first contribution in https://github.com/dani-garcia/vaultwarden/pull/7057
Full Changelog: https://github.com/dani-garcia/vaultwarden/compare/1.35.8...1.36.0

—
This release has 2 assets:

Source code (zip)
Source code (tar.gz)
Visit the [release page](https://github.com/dani-garcia/vaultwarden/releases/tag/1.36.0) to download them.