### PR TITLE
feat: add Kubernetes Gateway API (HTTPRoute) support

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.36.4
+version: 0.37.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -590,6 +590,18 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `ingress.nginxAllowList`          | Comma-separated list of IP addresses and subnets to allow.                     | `""`                 |
 | `ingress.customHeadersConfigMap`  | ConfigMap containing custom headers to be added to the ingress.                | `{}`                 |
 
+### Kubernetes Gateway API Configuration
+
+| Name                              | Description                                                                               | Value   |
+| --------------------------------- | ----------------------------------------------------------------------------------------- | ------- |
+| `httpRoute.enabled`               | Deploy an HTTPRoute resource (Kubernetes Gateway API).                                    | `false` |
+| `httpRoute.labels`                | Additional labels for the HTTPRoute resource.                                             | `{}`    |
+| `httpRoute.additionalAnnotations` | Additional annotations for the HTTPRoute resource.                                        | `{}`    |
+| `httpRoute.parentRefs`            | List of parent Gateway references. Required when enabled.                                 | `[]`    |
+| `httpRoute.hostnames`             | Hostnames this HTTPRoute should match.                                                    | `[]`    |
+| `httpRoute.path`                  | Default path prefix for the routing rule. Used only when httpRoute.rules is not set.      | `/`     |
+| `httpRoute.rules`                 | Custom routing rules. When set, overrides the default rule generated from httpRoute.path. | `[]`    |
+
 ### SSO OpenID Connect Configuration support for https://github.com/dani-garcia/vaultwarden/pull/3899
 
 | Name                                 | Description                                                                                                                                                              | Value                                                                                                                                           |

--- a/charts/vaultwarden/templates/NOTES.txt
+++ b/charts/vaultwarden/templates/NOTES.txt
@@ -3,5 +3,18 @@
 Thanks for installing {{ .Chart.Name }}.
 
 You have named your release: {{ .Release.Name }}.
+{{- if .Values.ingress.enabled }}
 
 Vaultwarden is accessible here: {{ .Values.ingress.hostname }}
+{{- else if .Values.httpRoute.enabled }}
+{{- if .Values.httpRoute.hostnames }}
+
+Vaultwarden is accessible here: {{ index .Values.httpRoute.hostnames 0 }}
+{{- else }}
+
+Vaultwarden is accessible via the configured Gateway (HTTPRoute has no hostnames set).
+{{- end }}
+{{- else }}
+
+Vaultwarden is deployed. To expose it externally, enable ingress or httpRoute in your values.
+{{- end }}

--- a/charts/vaultwarden/templates/httproute.yaml
+++ b/charts/vaultwarden/templates/httproute.yaml
@@ -1,0 +1,40 @@
+{{- $httpRoute := .Values.httpRoute -}}
+{{- if $httpRoute.enabled }}
+{{- if empty $httpRoute.parentRefs }}
+{{- fail "httpRoute.parentRefs must be configured when httpRoute.enabled is true" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "vaultwarden.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: vaultwarden
+    {{- include "vaultwarden.labels" . | nindent 4 }}
+    {{- range $key, $value := $httpRoute.labels }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- if $httpRoute.additionalAnnotations }}
+  annotations:
+    {{- toYaml $httpRoute.additionalAnnotations | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $httpRoute.parentRefs | nindent 4 }}
+  {{- if $httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml $httpRoute.hostnames | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if $httpRoute.rules }}
+    {{- toYaml $httpRoute.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $httpRoute.path | quote }}
+      backendRefs:
+        - name: {{ include "vaultwarden.fullname" . }}
+          port: 80
+    {{- end }}
+{{- end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -815,6 +815,55 @@ ingress:
   ##   - Support for multiple TLS hostnames.
   ##
 
+## @section Kubernetes Gateway API Configuration
+## Ref: https://gateway-api.sigs.k8s.io/
+##
+
+httpRoute:
+  ## @param httpRoute.enabled Deploy an HTTPRoute resource (Kubernetes Gateway API).
+  ## Requires the Gateway API CRDs to be installed in the cluster.
+  ## Ref: https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api
+  ##
+  enabled: false
+  ## @param httpRoute.labels Additional labels for the HTTPRoute resource.
+  ##
+  labels: {}
+  ## @param httpRoute.additionalAnnotations Additional annotations for the HTTPRoute resource.
+  ##
+  additionalAnnotations: {}
+  ## @param httpRoute.parentRefs List of parent Gateway references. Required when enabled.
+  ## Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference
+  ## Example:
+  ## parentRefs:
+  ##   - name: my-gateway
+  ##     namespace: gateway-system
+  ##     sectionName: https
+  ##
+  parentRefs: []
+  ## @param httpRoute.hostnames Hostnames this HTTPRoute should match.
+  ## Equivalent to the host field in an Ingress rule. Leave empty to match all hostnames.
+  ## Example:
+  ## hostnames:
+  ##   - "vw.example.com"
+  ##
+  hostnames: []
+  ## @param httpRoute.path Default path prefix for the routing rule. Used only when httpRoute.rules is not set.
+  ##
+  path: "/"
+  ## @param httpRoute.rules Custom routing rules. When set, overrides the default rule generated from httpRoute.path.
+  ## Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule
+  ## Example:
+  ## rules:
+  ##   - matches:
+  ##       - path:
+  ##           type: PathPrefix
+  ##           value: /
+  ##     backendRefs:
+  ##       - name: my-service
+  ##         port: 80
+  ##
+  rules: []
+
 ## @section SSO OpenID Connect Configuration support for https://github.com/dani-garcia/vaultwarden/pull/3899
 ##
 sso:


### PR DESCRIPTION
Closes #212

Adds native support for the Gateway API HTTPRoute resource as an alternative to the classic Ingress resource. Users migrating to the Gateway API no longer need to maintain a separate HTTPRoute manifest alongside the Helm release.

Changes:
- New template: templates/httproute.yaml renders a gateway.networking.k8s.io/v1 HTTPRoute when httpRoute.enabled=true
- values.yaml: new httpRoute block with parentRefs, hostnames, path, labels, additionalAnnotations, and optional rules override
- NOTES.txt: conditional URL hint based on active exposure method; fallback message when neither ingress nor httpRoute is configured
- Chart version bumped 0.36.4 → 0.37.0 (minor; new feature)
- README regenerated with new parameter table

Change-Id: 4d671bd73de6a1c72c97d182887dc96e