### PR TITLE
feat(hibp): allow existing secret

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.37.0
+version: 0.38.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.36.4
+version: 0.37.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -481,26 +481,29 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 
 ### General settings
 
-| Name                        | Description                                                                                  | Value         |
-| --------------------------- | -------------------------------------------------------------------------------------------- | ------------- |
-| `domain`                    | Domain name where the application is accessed                                                | `""`          |
-| `sendsAllowed`              | Controls whether users are allowed to create Bitwarden Sends.                                | `true`        |
-| `hibpApiKey`                | HaveIBeenPwned API Key                                                                       | `""`          |
-| `orgAttachmentLimit`        | Max Kilobytes of attachment storage allowed per organization.                                | `""`          |
-| `userAttachmentLimit`       | Max kilobytes of attachment storage allowed per user.                                        | `""`          |
-| `userSendLimit`             | Max kilobytes of send storage allowed per user.                                              | `""`          |
-| `trashAutoDeleteDays`       | Number of days to wait before auto-deleting a trashed item.                                  | `""`          |
-| `signupsAllowed`            | By default, anyone who can access your instance can register for a new account.              | `true`        |
-| `signupsVerify`             | Whether to require account verification for newly-registered users.                          | `true`        |
-| `signupDomains`             | List of domain names for users allowed to register. For example:                             | `""`          |
-| `orgEventsEnabled`          | Controls whether event logging is enabled for organizations                                  | `false`       |
-| `orgCreationUsers`          | Controls which users can create new orgs.                                                    | `""`          |
-| `invitationsAllowed`        | Even when registration is disabled, organization administrators or owners can                | `true`        |
-| `invitationOrgName`         | String Name shown in the invitation emails that don't come from a specific organization      | `Vaultwarden` |
-| `invitationExpirationHours` | The number of hours after which an organization invite token, emergency access invite token, | `120`         |
-| `emergencyAccessAllowed`    | Controls whether users can enable emergency access to their accounts.                        | `true`        |
-| `emailChangeAllowed`        | Controls whether users can change their email.                                               | `true`        |
-| `showPassHint`              | Controls whether a password hint should be shown directly in the web page if                 | `false`       |
+| Name                        | Description                                                                                        | Value         |
+| --------------------------- | -------------------------------------------------------------------------------------------------- | ------------- |
+| `domain`                    | Domain name where the application is accessed                                                      | `""`          |
+| `sendsAllowed`              | Controls whether users are allowed to create Bitwarden Sends.                                      | `true`        |
+| `hibpApiKey`                | HaveIBeenPwned API Key (legacy). Prefer `hibp.value` or `hibp.existingSecret`.                     | `""`          |
+| `hibp.existingSecret`       | Name of an existing secret containing the HaveIBeenPwned API key. Also set hibp.existingSecretKey. | `""`          |
+| `hibp.existingSecretKey`    | When using an existing secret, specify the key which contains the API key.                         | `""`          |
+| `hibp.value`                | HaveIBeenPwned API Key plain text                                                                  | `""`          |
+| `orgAttachmentLimit`        | Max Kilobytes of attachment storage allowed per organization.                                      | `""`          |
+| `userAttachmentLimit`       | Max kilobytes of attachment storage allowed per user.                                              | `""`          |
+| `userSendLimit`             | Max kilobytes of send storage allowed per user.                                                    | `""`          |
+| `trashAutoDeleteDays`       | Number of days to wait before auto-deleting a trashed item.                                        | `""`          |
+| `signupsAllowed`            | By default, anyone who can access your instance can register for a new account.                    | `true`        |
+| `signupsVerify`             | Whether to require account verification for newly-registered users.                                | `true`        |
+| `signupDomains`             | List of domain names for users allowed to register. For example:                                   | `""`          |
+| `orgEventsEnabled`          | Controls whether event logging is enabled for organizations                                        | `false`       |
+| `orgCreationUsers`          | Controls which users can create new orgs.                                                          | `""`          |
+| `invitationsAllowed`        | Even when registration is disabled, organization administrators or owners can                      | `true`        |
+| `invitationOrgName`         | String Name shown in the invitation emails that don't come from a specific organization            | `Vaultwarden` |
+| `invitationExpirationHours` | The number of hours after which an organization invite token, emergency access invite token,       | `120`         |
+| `emergencyAccessAllowed`    | Controls whether users can enable emergency access to their accounts.                              | `true`        |
+| `emailChangeAllowed`        | Controls whether users can change their email.                                                     | `true`        |
+| `showPassHint`              | Controls whether a password hint should be shown directly in the web page if                       | `false`       |
 
 ### Advanced settings
 

--- a/charts/vaultwarden/templates/_helpers.tpl
+++ b/charts/vaultwarden/templates/_helpers.tpl
@@ -92,3 +92,21 @@ Determine whether to use deployment or statefulset
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return true when the HIBP API key should be sourced from a Kubernetes Secret.
+*/}}
+{{- define "vaultwarden.hibpUseSecret" -}}
+{{- if or .Values.hibp.value .Values.hibp.existingSecret .Values.hibp.existingSecretKey -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the legacy hibpApiKey string value when hibpApiKey is set and hibp is not configured.
+*/}}
+{{- define "vaultwarden.hibpApiKeyLegacy" -}}
+{{- if and (not (include "vaultwarden.hibpUseSecret" .)) (kindIs "string" .Values.hibpApiKey) .Values.hibpApiKey -}}
+{{- .Values.hibpApiKey -}}
+{{- end -}}
+{{- end -}}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -86,6 +86,15 @@ containers:
             name: {{ default (include "vaultwarden.fullname" .) .Values.smtp.existingSecret }}
             key: {{ default "SMTP_PASSWORD" .Values.smtp.password.existingSecretKey }}
       {{- end }}
+      {{- if eq (include "vaultwarden.hibpUseSecret" .) "true" }}
+      {{- if or (.Values.hibp.value) (.Values.hibp.existingSecretKey) (.Values.hibp.existingSecret) }}
+      - name: HIBP_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: {{ default (include "vaultwarden.fullname" .) .Values.hibp.existingSecret }}
+            key: {{ default "HIBP_API_KEY" .Values.hibp.existingSecretKey }}
+      {{- end }}
+      {{- end }}
       {{- if and .Values.sso.enabled (or (.Values.sso.clientId.value) (.Values.sso.clientId.existingSecretKey) )}}
       - name: SSO_CLIENT_ID
         valueFrom:

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -109,7 +109,7 @@ data:
   {{- with .Values.timeZone }}
   TZ: {{ . | quote }}
   {{- end }}
-  {{- with .Values.hibpApiKey }}
+  {{- with include "vaultwarden.hibpApiKeyLegacy" . }}
   HIBP_API_KEY: {{ . | quote }}
   {{- end }}
   {{- with .Values.orgAttachmentLimit }}

--- a/charts/vaultwarden/templates/secrets.yaml
+++ b/charts/vaultwarden/templates/secrets.yaml
@@ -33,4 +33,7 @@ data:
   {{- if not ( .Values.adminToken.existingSecret ) }}
   ADMIN_TOKEN: {{ .Values.adminToken.value | b64enc | quote }}
   {{- end }}
+  {{- if and (not .Values.hibp.existingSecret) .Values.hibp.value }}
+  HIBP_API_KEY: {{ .Values.hibp.value | b64enc | quote }}
+  {{- end }}
 {{ end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -441,9 +441,23 @@ domain: ""
 ##
 sendsAllowed: "true"
 
-## @param hibpApiKey HaveIBeenPwned API Key
+## @param hibpApiKey HaveIBeenPwned API Key (legacy). Prefer `hibp.value` or `hibp.existingSecret`.
 ##
 hibpApiKey: ""
+
+## HaveIBeenPwned API Key
+##
+hibp:
+  ## @param hibp.existingSecret Name of an existing secret containing the HaveIBeenPwned API key. Also set hibp.existingSecretKey.
+  ##
+  existingSecret: ""
+  ## @param hibp.existingSecretKey When using an existing secret, specify the key which contains the API key.
+  ## Example: HIBP_API_KEY
+  ##
+  existingSecretKey: ""
+  ## @param hibp.value HaveIBeenPwned API Key plain text
+  ##
+  value: ""
 
 ## @param orgAttachmentLimit Max Kilobytes of attachment storage allowed per organization.
 ## When this limit is reached, organization members will not be allowed to upload further attachments for ciphers owned by that organization.


### PR DESCRIPTION
# Description

Adds support for providing the HaveIBeenPwned (HIBP) API key from a Kubernetes Secret, so it no longer has to live in plain text in values.yaml file or the ConfigMap.

A new `hibp` values block supports either a chart-managed secret (`hibp.value`) or an existing secret (`hibp.existingSecret` / `hibp.existingSecretKey`), following the same pattern as `adminToken`, `smtp`, and `database`.

The existing hibpApiKey setting is unchanged for backward compatibility. When `hibp` is configured, it takes precedence.

# But why tho?

The HIBP API key is sensitive. Storing it directly in values or the ConfigMap makes it easy to leak via git history, Helm release metadata, or cluster RBAC. Referencing an existing Secret (e.g. one created by Sealed Secrets, External Secrets, or your platform’s secret manager) is a safer and more common production pattern.

# Example

```yaml
# Using an existing secret (the new feature):
hibp:
  existingSecret: vaultwarden-hibp
  existingSecretKey: HIBP_API_KEY

# Using a chart-managed secret:
hibp:
  value: "your-api-key"

# Legacy implementation (left unchanged):
hibpApiKey: "your-api-key"
```

# AI Disclosure

I used [Cursor](https://cursor.com/) as an AI-assisting IDE, and it assisted me with the new chart templates. All of the code in this contribution was reviewed by me, @santiagon610, a human.