### PR TITLE
feat: add support for HELO_NAME in SMTP settings

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: lester@guerzon.net
     url: https://github.com/guerzon
-version: 0.42.0
+version: 0.43.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -569,6 +569,7 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `smtp.authMechanism`              | SMTP authentication mechanism                                                                                                                       | `Plain`    |
 | `smtp.acceptInvalidHostnames`     | Accept Invalid Hostnames                                                                                                                            | `false`    |
 | `smtp.acceptInvalidCerts`         | Accept Invalid Certificates                                                                                                                         | `false`    |
+| `smtp.heloName`                   | HELO Hostname: override the pod hostname used in the SMTP HELO command                                                                              | `""`       |
 | `smtp.debug`                      | SMTP debugging                                                                                                                                      | `false`    |
 
 ### Exposure settings

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -578,6 +578,8 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `rocket.address`                  | Address to bind to                                                             | `0.0.0.0`            |
 | `rocket.port`                     | Rocket port                                                                    | `8080`               |
 | `rocket.workers`                  | Rocket number of workers                                                       | `10`                 |
+| `rocket.tls.secretName`           | Name of the kubernetes.io/tls secret to use for HTTPS.                         | `""`                 |
+| `rocket.tls.path`                 | Path to mount TLS secrets within the container                                 | `/certs`             |
 | `service.type`                    | Service type                                                                   | `ClusterIP`          |
 | `service.annotations`             | Additional annotations for the vaultwarden service                             | `{}`                 |
 | `service.labels`                  | Additional labels for the service                                              | `{}`                 |

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -35,6 +35,9 @@ data:
   SMTP_DEBUG: {{ .Values.smtp.debug | quote }}
   SMTP_ACCEPT_INVALID_HOSTNAMES: {{ .Values.smtp.acceptInvalidHostnames | quote }}
   SMTP_ACCEPT_INVALID_CERTS: {{ .Values.smtp.acceptInvalidCerts | quote }}
+  {{- if .Values.smtp.heloName }}
+  HELO_NAME: {{ .Values.smtp.heloName | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.storage.data }}
   DATA_FOLDER: {{ default "/data" .Values.storage.data.path | quote }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -750,6 +750,9 @@ smtp:
   ## @param smtp.acceptInvalidCerts Accept Invalid Certificates
   ##
   acceptInvalidCerts: "false"
+  ## @param smtp.heloName HELO Hostname: override the pod hostname used in the SMTP HELO command
+  ##
+  heloName: ""
   ## @param smtp.debug SMTP debugging
   ##
   debug: false


### PR DESCRIPTION
As it stands, the chart only allows customization of the [HELO_NAME](https://github.com/dani-garcia/vaultwarden/wiki/SMTP-configuration#helo-hostname) envVar via `image.extraVars`.

This would be cleaner in SMTP setttings