### PR TITLE
feat(httproute): support multiple named routes and httpsRedirect

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: guerzon@proton.me
     url: https://github.com/guerzon
-version: 0.38.0
+version: 0.39.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -595,15 +595,9 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 
 ### Kubernetes Gateway API Configuration
 
-| Name                              | Description                                                                               | Value   |
-| --------------------------------- | ----------------------------------------------------------------------------------------- | ------- |
-| `httpRoute.enabled`               | Deploy an HTTPRoute resource (Kubernetes Gateway API).                                    | `false` |
-| `httpRoute.labels`                | Additional labels for the HTTPRoute resource.                                             | `{}`    |
-| `httpRoute.additionalAnnotations` | Additional annotations for the HTTPRoute resource.                                        | `{}`    |
-| `httpRoute.parentRefs`            | List of parent Gateway references. Required when enabled.                                 | `[]`    |
-| `httpRoute.hostnames`             | Hostnames this HTTPRoute should match.                                                    | `[]`    |
-| `httpRoute.path`                  | Default path prefix for the routing rule. Used only when httpRoute.rules is not set.      | `/`     |
-| `httpRoute.rules`                 | Custom routing rules. When set, overrides the default rule generated from httpRoute.path. | `[]`    |
+| Name        | Description                                                        | Value |
+| ----------- | ------------------------------------------------------------------ | ----- |
+| `httpRoute` | HTTPRoute configuration. Supports two shapes — see examples below. | `{}`  |
 
 ### SSO OpenID Connect Configuration support for https://github.com/dani-garcia/vaultwarden/pull/3899
 

--- a/charts/vaultwarden/templates/NOTES.txt
+++ b/charts/vaultwarden/templates/NOTES.txt
@@ -6,13 +6,29 @@ You have named your release: {{ .Release.Name }}.
 {{- if .Values.ingress.enabled }}
 
 Vaultwarden is accessible here: {{ .Values.ingress.hostname }}
-{{- else if .Values.httpRoute.enabled }}
+{{- else if .Values.httpRoute }}
+{{- if hasKey .Values.httpRoute "enabled" }}
+{{- /* Flat shape (v0.37.0) */ -}}
+{{- if .Values.httpRoute.enabled }}
 {{- if .Values.httpRoute.hostnames }}
 
 Vaultwarden is accessible here: {{ index .Values.httpRoute.hostnames 0 }}
 {{- else }}
 
 Vaultwarden is accessible via the configured Gateway (HTTPRoute has no hostnames set).
+{{- end }}
+{{- else }}
+
+Vaultwarden is deployed. To expose it externally, enable ingress or httpRoute in your values.
+{{- end }}
+{{- else }}
+{{- /* Map shape — print a line for each non-redirect enabled route that has hostnames */ -}}
+{{- range $name, $route := .Values.httpRoute }}
+{{- if and (kindIs "map" $route) $route.enabled (not $route.httpsRedirect) $route.hostnames }}
+
+Vaultwarden ({{ $name }}) is accessible here: {{ index $route.hostnames 0 }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- else }}
 

--- a/charts/vaultwarden/templates/httproute.yaml
+++ b/charts/vaultwarden/templates/httproute.yaml
@@ -1,7 +1,36 @@
+{{- define "vaultwarden.httpRoute.rules" -}}
+{{- $route := .route -}}
+{{- $fullName := .fullName -}}
+{{- if $route.rules -}}
+{{ toYaml $route.rules }}
+{{- else if $route.httpsRedirect -}}
+- matches:
+    - path:
+        type: PathPrefix
+        value: {{ default "/" $route.path | quote }}
+  filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301
+{{- else -}}
+- matches:
+    - path:
+        type: PathPrefix
+        value: {{ default "/" $route.path | quote }}
+  backendRefs:
+    - name: {{ $fullName }}
+      port: 80
+{{- end -}}
+{{- end -}}
+{{- $root := . -}}
 {{- $httpRoute := .Values.httpRoute -}}
-{{- if $httpRoute.enabled }}
-{{- if empty $httpRoute.parentRefs }}
-{{- fail "httpRoute.parentRefs must be configured when httpRoute.enabled is true" }}
+{{- if and $httpRoute (kindIs "map" $httpRoute) -}}
+{{- if hasKey $httpRoute "enabled" -}}
+{{- /* Legacy flat shape (v0.37.0) */ -}}
+{{- if $httpRoute.enabled -}}
+{{- if empty $httpRoute.parentRefs -}}
+{{- fail "httpRoute.parentRefs must be configured when httpRoute.enabled is true" -}}
 {{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -12,7 +41,7 @@ metadata:
     app.kubernetes.io/component: vaultwarden
     {{- include "vaultwarden.labels" . | nindent 4 }}
     {{- range $key, $value := $httpRoute.labels }}
-    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- printf "%s: %s" $key (tpl $value $root | quote) | nindent 4 }}
     {{- end }}
   {{- if $httpRoute.additionalAnnotations }}
   annotations:
@@ -26,15 +55,41 @@ spec:
     {{- toYaml $httpRoute.hostnames | nindent 4 }}
   {{- end }}
   rules:
-    {{- if $httpRoute.rules }}
-    {{- toYaml $httpRoute.rules | nindent 4 }}
-    {{- else }}
-    - matches:
-        - path:
-            type: PathPrefix
-            value: {{ $httpRoute.path | quote }}
-      backendRefs:
-        - name: {{ include "vaultwarden.fullname" . }}
-          port: 80
-    {{- end }}
+    {{- include "vaultwarden.httpRoute.rules" (dict "route" $httpRoute "fullName" (include "vaultwarden.fullname" $root)) | nindent 4 }}
+{{- end -}}
+{{- else -}}
+{{- /* Map shape (v0.38.0+) — range over named routes */ -}}
+{{- range $name, $route := $httpRoute -}}
+{{- if and (kindIs "map" $route) $route.enabled -}}
+{{- if empty $route.parentRefs -}}
+{{- fail (printf "httpRoute.%s.parentRefs must be configured when route is enabled" $name) -}}
 {{- end }}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ include "vaultwarden.fullname" $root }}{{ if ne $name "main" }}-{{ $name }}{{ end }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: vaultwarden
+    {{- include "vaultwarden.labels" $root | nindent 4 }}
+    {{- range $key, $value := $route.labels }}
+    {{- printf "%s: %s" $key (tpl $value $root | quote) | nindent 4 }}
+    {{- end }}
+  {{- if $route.additionalAnnotations }}
+  annotations:
+    {{- toYaml $route.additionalAnnotations | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $route.parentRefs | nindent 4 }}
+  {{- if $route.hostnames }}
+  hostnames:
+    {{- toYaml $route.hostnames | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- include "vaultwarden.httpRoute.rules" (dict "route" $route "fullName" (include "vaultwarden.fullname" $root)) | nindent 4 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -833,50 +833,56 @@ ingress:
 ## Ref: https://gateway-api.sigs.k8s.io/
 ##
 
-httpRoute:
-  ## @param httpRoute.enabled Deploy an HTTPRoute resource (Kubernetes Gateway API).
-  ## Requires the Gateway API CRDs to be installed in the cluster.
-  ## Ref: https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api
-  ##
-  enabled: false
-  ## @param httpRoute.labels Additional labels for the HTTPRoute resource.
-  ##
-  labels: {}
-  ## @param httpRoute.additionalAnnotations Additional annotations for the HTTPRoute resource.
-  ##
-  additionalAnnotations: {}
-  ## @param httpRoute.parentRefs List of parent Gateway references. Required when enabled.
-  ## Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference
-  ## Example:
-  ## parentRefs:
-  ##   - name: my-gateway
-  ##     namespace: gateway-system
-  ##     sectionName: https
-  ##
-  parentRefs: []
-  ## @param httpRoute.hostnames Hostnames this HTTPRoute should match.
-  ## Equivalent to the host field in an Ingress rule. Leave empty to match all hostnames.
-  ## Example:
-  ## hostnames:
-  ##   - "vw.example.com"
-  ##
-  hostnames: []
-  ## @param httpRoute.path Default path prefix for the routing rule. Used only when httpRoute.rules is not set.
-  ##
-  path: "/"
-  ## @param httpRoute.rules Custom routing rules. When set, overrides the default rule generated from httpRoute.path.
-  ## Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule
-  ## Example:
-  ## rules:
-  ##   - matches:
-  ##       - path:
-  ##           type: PathPrefix
-  ##           value: /
-  ##     backendRefs:
-  ##       - name: my-service
-  ##         port: 80
-  ##
-  rules: []
+## @param httpRoute HTTPRoute configuration. Supports two shapes — see examples below.
+## Requires Gateway API CRDs to be installed in the cluster.
+## Ref: https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api
+##
+## Shape 1 — Flat (single HTTPRoute, backward-compatible with chart v0.37.0):
+## httpRoute:
+##   enabled: true
+##   labels: {}
+##   additionalAnnotations: {}
+##   parentRefs:
+##     - name: my-gateway
+##       namespace: gateway-system
+##       sectionName: https
+##   hostnames:
+##     - vw.example.com
+##   path: /
+##   rules: []           # full override; takes precedence over path and httpsRedirect
+##   httpsRedirect: false
+##
+## Shape 2 — Map (multiple named HTTPRoutes, e.g. HTTPS backend + HTTP-to-HTTPS redirect):
+## httpRoute:
+##   main:
+##     enabled: true
+##     parentRefs:
+##       - name: my-gateway
+##         namespace: gateway-system
+##         sectionName: https
+##     hostnames:
+##       - vw.example.com
+##     path: /
+##     rules: []
+##     httpsRedirect: false
+##     apiVersion: gateway.networking.k8s.io/v1   # optional override
+##     kind: HTTPRoute                             # optional override
+##     labels: {}
+##     additionalAnnotations: {}
+##   redirect:
+##     enabled: true
+##     parentRefs:
+##       - name: my-gateway
+##         namespace: gateway-system
+##         sectionName: http
+##     hostnames:
+##       - vw.example.com
+##     httpsRedirect: true   # emits a 301 RequestRedirect filter; no backendRefs
+##
+## Route naming: the "main" route uses the chart's fullname; all other routes get a
+## "-<name>" suffix (e.g. "<release>-vaultwarden-redirect").
+##
+httpRoute: {}
 
 ## @section SSO OpenID Connect Configuration support for https://github.com/dani-garcia/vaultwarden/pull/3899
 ##


### PR DESCRIPTION
Extend the existing single-route httpRoute block to support an arbitrary number of named HTTPRoute resources and a first-class httpsRedirect gate.

New map shape (v0.39.0+):
```yaml
  httpRoute:
    main:
      enabled: true
      parentRefs: [...]
      hostnames: [vw.example.com]
    redirect:
      enabled: true
      parentRefs: [...]
      httpsRedirect: true  # emits RequestRedirect 301; no backendRefs
```
The original flat shape (v0.37.0) is fully backward-compatible: the template detects mode at render time using `hasKey .Values.httpRoute "enabled"`. No values migration required for existing users.

Per-route rules logic (applied in both modes):
1. `rules:` set  -> full override, no defaults applied
2. `httpsRedirect: true` -> 301 RequestRedirect filter, no backendRefs
3. default -> PathPrefix `/` -> backendRefs to the chart Service:80

Route naming: the "main" route keeps the base fullname; every other route gets a `-<name>` suffix (e.g. `<release>-vaultwarden-redirect`) to avoid Kubernetes name collisions within the same namespace.

`parentRefs` is still required in both modes; omitting it raises a descriptive `fail()` at template render time.

Closes #220


Change-Id: 5c35769e18fe1b7055a9dd30bf153356