### PR TITLE
fix: leave serviceAccount.create as true

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: lester@guerzon.net
     url: https://github.com/guerzon
-version: 0.40.0
+version: 0.40.1
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -391,8 +391,8 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | `affinity`              | Affinity for pod assignment                                                               | `{}`                 |
 | `tolerations`           | Tolerations for pod assignment                                                            | `[]`                 |
 | `priorityClassName`     | Assign a priority class to pods                                                           | `""`                 |
-| `serviceAccount.create` | Create a service account                                                                  | `false`              |
-| `serviceAccount.name`   | Name of the service account to create                                                     | `""`                 |
+| `serviceAccount.create` | Create a service account                                                                  | `true`               |
+| `serviceAccount.name`   | Name of the service account to create                                                     | `vaultwarden-svc`    |
 | `podSecurityContext`    | Pod security options                                                                      | `{}`                 |
 | `securityContext`       | Default security options to run vault as read only container without privilege escalation | `{}`                 |
 | `dnsConfig`             | Pod DNS options                                                                           | `{}`                 |

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -121,8 +121,8 @@ priorityClassName: ""
 ## @param serviceAccount.name Name of the service account to create
 ##
 serviceAccount:
-  create: false
-  name: ""
+  create: true
+  name: "vaultwarden-svc"
 
 ## @param podSecurityContext Pod security options
 ##


### PR DESCRIPTION
Previous change #222 to disable the service account creation by default is a breaking change.

For existing users, they can instead delete the role and rolebinding, patch the deployment/statefulset, then delete the service account.