### PR TITLE
feat: add auto-deploy PostgreSQL as subchart

### DIFF
--- a/charts/vaultwarden/Chart.lock
+++ b/charts/vaultwarden/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 15.5.5
+digest: sha256:ca9d814ee740851d128c21458058f9900c13c7ea42c6e424578645739b98ec44
+generated: "2026-06-29T11:01:12.002736768+03:00"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -15,3 +15,9 @@ maintainers:
     url: https://github.com/guerzon
 version: 0.43.0
 kubeVersion: ">=1.12.0-0"
+
+dependencies:
+  - name: postgresql
+    version: "15.5.5"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: postgresql.enabled

--- a/charts/vaultwarden/templates/_helpers.tpl
+++ b/charts/vaultwarden/templates/_helpers.tpl
@@ -110,3 +110,26 @@ Return the legacy hibpApiKey string value when hibpApiKey is set and hibp is not
 {{- .Values.hibpApiKey -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "vaultwarden.dbString" -}}
+{{- if .Values.postgresql.enabled -}}
+  {{- printf "postgresql://%s:%s@%s-postgresql.%s.svc.cluster.local:%d/%s" 
+      "postgres" 
+      .Values.postgresql.auth.postgresPassword 
+      .Release.Name 
+      .Release.Namespace 
+      (int .Values.postgresql.service.ports.postgresql) 
+      .Values.postgresql.auth.database -}}
+{{- else -}}
+  {{- if .Values.database.existingSecret -}}
+    {{- include "vaultwarden.dbSecret" . -}}
+  {{- else -}}
+    {{- printf "postgresql://%s:%s@%s:%d/%s" 
+        .Values.database.username 
+        .Values.database.password 
+        .Values.database.host 
+        (int .Values.database.port) 
+        .Values.database.dbName -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/vaultwarden/templates/configmap.yaml
+++ b/charts/vaultwarden/templates/configmap.yaml
@@ -45,8 +45,10 @@ data:
   {{- if .Values.storage.attachments }}
   ATTACHMENTS_FOLDER: {{ default "/data/attachments" .Values.storage.attachments.path | quote }}
   {{- end }}
-  {{- with .Values.database.uriOverride }}
-  DATABASE_URL: {{ . | quote }}
+  {{- if .Values.database.uriOverride }}
+  DATABASE_URL: {{ .Values.database.uriOverride | quote }}
+  {{- else }}
+  DATABASE_URL: {{ include "vaultwarden.dbString" . | quote }}
   {{- end }}
   ROCKET_ADDRESS: {{ .Values.rocket.address | quote }}
   ROCKET_PORT: {{ .Values.rocket.port | quote }}

--- a/charts/vaultwarden/test-values.yaml
+++ b/charts/vaultwarden/test-values.yaml
@@ -1,0 +1,21 @@
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: 15-alpine
+  auth:
+    postgresPassword: "test-password"
+  primary:
+    persistence:
+      enabled: false
+    extraEnvVars:
+      - name: POSTGRES_DB
+        value: vaultwarden
+    extraVolumes:
+      - name: run-postgresql
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: run-postgresql
+        mountPath: /var/run/postgresql
+ingress:
+  enabled: false

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -976,3 +976,17 @@ sso:
     ## @param sso.clientSecret.existingSecretKey When using an existing secret, specify the key which contains the password.
     ##
     existingSecretKey: ""
+
+## PostgreSQL subchart configuration (auto-deploy)
+## @section PostgreSQL subchart settings
+postgresql:
+  enabled: false
+  auth:
+    postgresPassword: "change-me"
+    database: "vaultwarden"
+  primary:
+    persistence:
+      size: 10Gi
+  service:
+    ports:
+      postgresql: 5432


### PR DESCRIPTION
Что добавлено
- Добавлена возможность автоматического развертывания PostgreSQL через под-чарт `bitnami/postgresql`.
- В `Chart.yaml` добавлена зависимость.
- В `values.yaml` добавлена секция `postgresql` для управления автодеплоем.
- В `_helpers.tpl` добавлена функция `dbString`, которая формирует `DATABASE_URL` в зависимости от включенного автодеплоя.
- В `configmap.yaml` изменена логика формирования `DATABASE_URL` (используется `dbString`).
- Обновлена документация (README.md).

Зачем это нужно
Упрощает развертывание Vaultwarden: теперь можно одной командой поднять и приложение, и базу данных, без ручного создания PostgreSQL.

Как протестировано
- Установка в отдельном namespace с `postgresql.enabled=true`.
- Проверка, что Vaultwarden подключается к автоматически созданной БД.
- Проверка обратной совместимости (при `postgresql.enabled=false` используется внешняя БД).

Пример использования
```yaml
postgresql:
  enabled: true
  auth:
    postgresPassword: "secure-password"
    database: "vaultwarden"