### PR TITLE
fix ingress additional hostnames context

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: lester@guerzon.net
     url: https://github.com/guerzon
-version: 0.43.0
+version: 0.43.1
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -64,7 +64,7 @@ spec:
             service:
               name: {{ include "vaultwarden.fullname" $ }}
               port:
-                {{- if .Values.rocket.tls.secretName }}
+                {{- if $.Values.rocket.tls.secretName }}
                 name: "https"
                 {{- else }}
                 name: "http"


### PR DESCRIPTION
## Description
Fixes #232

The `{{- range $ingress.additionalHostnames }}` block in `ingress.yaml` changes the template context (`.`) to the current loop item (a hostname string). The check line, `{{- if .Values.rocket.tls.secretName }}`, was using `.` instead of the global context `$`, causing:

`Error: template: vaultwarden/templates/ingress.yaml:67:30: executing "vaultwarden/templates/ingress.yaml" at <.Values.rocket.tls.secretName>: can't evaluate field Values in type interface {}`

This only manifests when `ingress.additionalHostnames` is non-empty, which is why it can go unnoticed in simpler setups.

## Fix
Changed `.Values.rocket.tls.secretName` to `$.Values.rocket.tls.secretName`, consistent with the existing `$` usage a few lines above.

## Testing
- `helm template` with `ingress.additionalHostnames` set reproduces the   error on `main` and renders correctly after the fix.
- Verified `port.name` resolves to `https`/`http` correctly for both the   primary host and additional hostnames when `rocket.tls.secretName` is set.
- Verified no regression when `additionalHostnames` is empty.
- `helm lint .` passes. (actually Chart Icon is missing)

## Chart version
Changed `0.43.0` to `0.43.1` as per CONTRIBUTING.md guidelines 