### PR TITLE
feat(vaultwarden): add topologySpreadConstraints support

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: lester@guerzon.net
     url: https://github.com/guerzon
-version: 0.44.1
+version: 0.45.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -364,40 +364,41 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 
 ### Kubernetes settings
 
-| Name                    | Description                                                                               | Value                |
-| ----------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
-| `image.registry`        | Vaultwarden image registry                                                                | `docker.io`          |
-| `image.repository`      | Vaultwarden image repository                                                              | `vaultwarden/server` |
-| `image.tag`             | Vaultwarden image tag                                                                     | `1.37.1-alpine`      |
-| `image.pullPolicy`      | Vaultwarden image pull policy                                                             | `IfNotPresent`       |
-| `image.pullSecrets`     | Specify docker-registry secrets                                                           | `[]`                 |
-| `image.extraSecrets`    | Vaultwarden image extra secrets                                                           | `[]`                 |
-| `image.extraVars`       | Vaultwarden image extra vars                                                              | `[]`                 |
-| `image.extraVarsCM`     | Vaultwarden image extra vars ConfigMap                                                    | `""`                 |
-| `image.extraVarsSecret` | Vaultwarden image extra vars Secret                                                       | `""`                 |
-| `replicas`              | Number of deployment replicas                                                             | `1`                  |
-| `fullnameOverride`      | String to override the application name.                                                  | `""`                 |
-| `resourceType`          | Can be either Deployment or StatefulSet                                                   | `""`                 |
-| `commonAnnotations`     | Annotations for the deployment or statefulset                                             | `{}`                 |
-| `configMapAnnotations`  | Add extra annotations to the configmap                                                    | `{}`                 |
-| `podAnnotations`        | Add extra annotations to the pod                                                          | `{}`                 |
-| `commonLabels`          | Additional labels for the deployment or statefulset                                       | `{}`                 |
-| `podLabels`             | Add extra labels to the pod                                                               | `{}`                 |
-| `initContainers`        | extra init containers for initializing the vaultwarden instance                           | `[]`                 |
-| `sidecars`              | extra containers running alongside the vaultwarden instance                               | `[]`                 |
-| `extraVolumes`          | Optionally specify extra list of additional volumes                                       | `[]`                 |
-| `extraVolumeMounts`     | Optionally specify extra list of additional volumeMounts                                  | `[]`                 |
-| `nodeSelector`          | Node labels for pod assignment                                                            | `{}`                 |
-| `affinity`              | Affinity for pod assignment                                                               | `{}`                 |
-| `tolerations`           | Tolerations for pod assignment                                                            | `[]`                 |
-| `priorityClassName`     | Assign a priority class to pods                                                           | `""`                 |
-| `serviceAccount.create` | Create a service account                                                                  | `true`               |
-| `serviceAccount.name`   | Name of the service account to create                                                     | `vaultwarden-svc`    |
-| `podSecurityContext`    | Pod security options                                                                      | `{}`                 |
-| `securityContext`       | Default security options to run vault as read only container without privilege escalation | `{}`                 |
-| `dnsConfig`             | Pod DNS options                                                                           | `{}`                 |
-| `enableServiceLinks`    | Enable service links, Kubernetes default is true                                          | `true`               |
-| `extraObjects`          | List of extra Kubernetes objects to create                                                | `[]`                 |
+| Name                        | Description                                                                               | Value                |
+| --------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
+| `image.registry`            | Vaultwarden image registry                                                                | `docker.io`          |
+| `image.repository`          | Vaultwarden image repository                                                              | `vaultwarden/server` |
+| `image.tag`                 | Vaultwarden image tag                                                                     | `1.37.1-alpine`      |
+| `image.pullPolicy`          | Vaultwarden image pull policy                                                             | `IfNotPresent`       |
+| `image.pullSecrets`         | Specify docker-registry secrets                                                           | `[]`                 |
+| `image.extraSecrets`        | Vaultwarden image extra secrets                                                           | `[]`                 |
+| `image.extraVars`           | Vaultwarden image extra vars                                                              | `[]`                 |
+| `image.extraVarsCM`         | Vaultwarden image extra vars ConfigMap                                                    | `""`                 |
+| `image.extraVarsSecret`     | Vaultwarden image extra vars Secret                                                       | `""`                 |
+| `replicas`                  | Number of deployment replicas                                                             | `1`                  |
+| `fullnameOverride`          | String to override the application name.                                                  | `""`                 |
+| `resourceType`              | Can be either Deployment or StatefulSet                                                   | `""`                 |
+| `commonAnnotations`         | Annotations for the deployment or statefulset                                             | `{}`                 |
+| `configMapAnnotations`      | Add extra annotations to the configmap                                                    | `{}`                 |
+| `podAnnotations`            | Add extra annotations to the pod                                                          | `{}`                 |
+| `commonLabels`              | Additional labels for the deployment or statefulset                                       | `{}`                 |
+| `podLabels`                 | Add extra labels to the pod                                                               | `{}`                 |
+| `initContainers`            | extra init containers for initializing the vaultwarden instance                           | `[]`                 |
+| `sidecars`                  | extra containers running alongside the vaultwarden instance                               | `[]`                 |
+| `extraVolumes`              | Optionally specify extra list of additional volumes                                       | `[]`                 |
+| `extraVolumeMounts`         | Optionally specify extra list of additional volumeMounts                                  | `[]`                 |
+| `nodeSelector`              | Node labels for pod assignment                                                            | `{}`                 |
+| `affinity`                  | Affinity for pod assignment                                                               | `{}`                 |
+| `tolerations`               | Tolerations for pod assignment                                                            | `[]`                 |
+| `topologySpreadConstraints` | Topology spread constraints for pod assignment                                            | `[]`                 |
+| `priorityClassName`         | Assign a priority class to pods                                                           | `""`                 |
+| `serviceAccount.create`     | Create a service account                                                                  | `true`               |
+| `serviceAccount.name`       | Name of the service account to create                                                     | `vaultwarden-svc`    |
+| `podSecurityContext`        | Pod security options                                                                      | `{}`                 |
+| `securityContext`           | Default security options to run vault as read only container without privilege escalation | `{}`                 |
+| `dnsConfig`                 | Pod DNS options                                                                           | `{}`                 |
+| `enableServiceLinks`        | Enable service links, Kubernetes default is true                                          | `true`               |
+| `extraObjects`              | List of extra Kubernetes objects to create                                                | `[]`                 |
 
 ### Reliability configuration
 

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -15,6 +15,10 @@ affinity:
 tolerations:
 {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with .Values.priorityClassName }}
 priorityClassName: {{ . | quote }}
 {{- end }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -112,6 +112,11 @@ affinity: {}
 ##
 tolerations: []
 
+## @param topologySpreadConstraints Topology spread constraints for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+##
+topologySpreadConstraints: []
+
 ## @param priorityClassName Assign a priority class to pods
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
 ##


### PR DESCRIPTION
## What this does

Adds an opt-in `topologySpreadConstraints` field so pods can be spread across zones/nodes for higher availability. This complements the existing `nodeSelector`, `affinity`, `tolerations`, and `priorityClassName` scheduling knobs already exposed on the pod spec.

## Why

Multi-node clusters running more than one replica (`replicas > 1`, or a StatefulSet) currently have no built-in way to enforce even pod distribution across topology domains. `topologySpreadConstraints` is the standard Kubernetes primitive for this and rounds out the scheduling surface of the chart.

## Changes

- `templates/_podSpec.tpl` — render `topologySpreadConstraints` from values (shared by both the Deployment and StatefulSet paths via `vaultwarden.podSpec`)
- `values.yaml` — new `topologySpreadConstraints: []` parameter with `@param` doc annotation
- `README.md` — regenerated via the bitnami `readme-generator-for-helm` tool (`generate-readme.sh`)
- `Chart.yaml` — version bump `0.43.1` → `0.44.0` (SemVer minor, per CONTRIBUTING)

## Backward compatibility

The field defaults to `[]`, so the `{{- with .Values.topologySpreadConstraints }}` block is skipped when unset. Rendered output for existing users is **byte-identical** (verified with `helm template` diff against `main`, version bump aside).

## Usage

```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
    labelSelector:
      matchLabels:
        app.kubernetes.io/name: vaultwarden
```

## Testing

- `helm lint` — pass
- `ct lint` — pass
- `helm template` with the field set renders `topologySpreadConstraints` correctly on both Deployment and StatefulSet
- `helm template` with the field unset is byte-identical to `main`