### PR TITLE
feat: add custom labels to storage PVCs

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: lester@guerzon.net
     url: https://github.com/guerzon
-version: 0.43.1
+version: 0.44.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -337,6 +337,18 @@ attachments:
   keepPvc: true
 ```
 
+To add custom labels to the persistent volume claims, set the `labels` key. This is useful for backup tools, monitoring, or policies that select volumes by label:
+
+```yaml
+data:
+  name: "vaultwarden-data"
+  size: "15Gi"
+  class: "local-path"
+  labels:
+    environment: "production"
+    team: "platform"
+```
+
 ### Using an Existing Persistent Volume Claim
 
 In case you want to use an existing PVC to store your data and attachments (i.e. NAS), `storage.existingVolumeClaim` can be set, which will update the PodSpec to use the provided PVC.  Note, that use of this value will ignore the values of both `storage.data` 

--- a/charts/vaultwarden/templates/_pvcSpec.tpl
+++ b/charts/vaultwarden/templates/_pvcSpec.tpl
@@ -8,6 +8,9 @@ volumeClaimTemplates:
         app.kubernetes.io/component: vaultwarden
         app.kubernetes.io/name: {{ include "vaultwarden.fullname" $ }}
         app.kubernetes.io/instance: {{ include "vaultwarden.fullname" $ }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         meta.helm.sh/release-name: {{ $.Release.Name | quote }}
         meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}
@@ -31,6 +34,9 @@ volumeClaimTemplates:
         app.kubernetes.io/component: vaultwarden
         app.kubernetes.io/name: {{ include "vaultwarden.fullname" $ }}
         app.kubernetes.io/instance: {{ include "vaultwarden.fullname" $ }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         meta.helm.sh/release-name: {{ $.Release.Name | quote }}
         meta.helm.sh/release-namespace: {{ $.Release.Namespace | quote }}

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -306,6 +306,7 @@ storage:
     # path: "/data"
     # keepPvc: false
     # accessMode: "ReadWriteOnce"
+    # labels: {}
 
   ## @param storage.attachments Attachments directory configuration, refer to values.yaml for parameters.
   ## By default, attachments/ is located inside the data directory.
@@ -318,6 +319,7 @@ storage:
     # path: /files
     # keepPvc: false
     # accessMode: "ReadWriteOnce"
+    # labels: {}
 
 ## @param webVaultEnabled Enable Web Vault
 ##


### PR DESCRIPTION
Adds support for setting custom labels on the storage PVCs (`storage.data` and `storage.attachments`), rendered on the `volumeClaimTemplates` of the StatefulSet.

## Why

Some controllers select PersistentVolumeClaims **by label**, not by annotation or pod. My use case is [Longhorn](https://longhorn.io/)'s backup automation: a Longhorn `RecurringJob` runs backups against the volumes that carry a specific label — there is no annotation or pod-based alternative for this. See the docs:

- [RecurringJob](https://longhorn.io/docs/latest/snapshots-and-backups/scheduling-backups-and-snapshots/) — jobs act on volumes grouped by the label `recurring-job-group.longhorn.io/<group>`.

Today the chart hardcodes the PVC labels (only the `app.kubernetes.io/*` set), so there is no way to add such a selector label from values. The only workarounds are `storage.existingVolumeClaim` (manage the PVC yourself) or a manual `kubectl label`, both of which break the GitOps flow.

Custom PVC labels are useful beyond this single case — e.g. selecting volumes for other backup/snapshot operators (Velero, Kanister) that also act on volumes by label.

## Changes

- `templates/_pvcSpec.tpl`: render `storage.data.labels` and `storage.attachments.labels` on the respective `volumeClaimTemplates`, merged after the existing `app.kubernetes.io/*` labels
- `values.yaml`: document the new optional `labels` key under `storage.data` and `storage.attachments`
- `Chart.yaml`: version bump 0.43.1 → 0.44.0 (minor; new feature)
- README regenerated (no parameter-table change: `storage.data`/`storage.attachments` are documented as dictionaries)

## Notes

- Backwards compatible: with no `labels` set, the rendered output is unchanged.
- Since `volumeClaimTemplates` are immutable on an existing StatefulSet, labels apply to newly provisioned PVCs (same as the existing PVC fields).

## Example

```yaml
storage:
  data:
    name: vaultwarden-data
    size: 5Gi
    accessMode: ReadWriteOnce
    labels:
      recurring-job-group.longhorn.io/backup: enabled
```
