### PR TITLE
feat: add image.flavor to select the Alpine or Debian image

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: guerzon
     email: lester@guerzon.net
     url: https://github.com/guerzon
-version: 0.46.1
+version: 0.47.0
 kubeVersion: ">=1.12.0-0"

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -29,7 +29,7 @@ helm upgrade -i \
 
 ## General configuration
 
-This chart deploys `vaultwarden` from pre-built images on [Docker Hub](https://hub.docker.com/r/vaultwarden/server/tags): `vaultwarden/server`. The image can be defined by specifying the tag with `image.tag`.
+This chart deploys `vaultwarden` from pre-built images on [Docker Hub](https://hub.docker.com/r/vaultwarden/server/tags): `vaultwarden/server`. The image is composed from `image.tag` and `image.flavor`, so `tag: "1.24.0"` with `flavor: "alpine"` resolves to `1.24.0-alpine`.
 
 Example that uses the Alpine-based image `1.24.0-alpine` and an existing secret that contains registry credentials:
 
@@ -37,9 +37,18 @@ Example that uses the Alpine-based image `1.24.0-alpine` and an existing secret 
 image:
   registry: ghcr.io
   repository: guerzon/vaultwarden
-  tag: "1.24.0-alpine"
+  tag: "1.24.0"
+  flavor: "alpine"
   pullSecrets:
     - name: myRegKey
+```
+
+Upstream publishes an Alpine (musl) and a Debian (glibc) image for each release. Set `flavor: ""` to get the Debian image, which is the safer choice on clusters where musl's resolver misbehaves:
+
+```yaml
+image:
+  tag: "1.24.0"
+  flavor: ""
 ```
 
 **Important**: specify the URL used by users with the `domain` variable, otherwise, some functionalities might not work:
@@ -380,7 +389,8 @@ helm -n $NAMESPACE uninstall $RELEASE_NAME
 | --------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`            | Vaultwarden image registry                                                                | `docker.io`          |
 | `image.repository`          | Vaultwarden image repository                                                              | `vaultwarden/server` |
-| `image.tag`                 | Vaultwarden image tag                                                                     | `1.37.2-alpine`      |
+| `image.tag`                 | Vaultwarden image tag, without the flavor suffix                                          | `1.37.2`             |
+| `image.flavor`              | Image flavor, appended to `image.tag`. Set to `""` for the Debian (glibc) image           | `alpine`             |
 | `image.pullPolicy`          | Vaultwarden image pull policy                                                             | `IfNotPresent`       |
 | `image.pullSecrets`         | Specify docker-registry secrets                                                           | `[]`                 |
 | `image.extraSecrets`        | Vaultwarden image extra secrets                                                           | `[]`                 |

--- a/charts/vaultwarden/ci/test-values.yaml
+++ b/charts/vaultwarden/ci/test-values.yaml
@@ -11,6 +11,7 @@ adminToken:
   value: "khit9gYQV6ax9LKTTm+s6QbZi5oiuR+3s1PEn9q3IRmCl9IQn7LmBpmFCOYTb7Mr"
 
 image:
+  flavor: ""
   pullSecrets:
     - name: myRegKey
 

--- a/charts/vaultwarden/templates/_helpers.tpl
+++ b/charts/vaultwarden/templates/_helpers.tpl
@@ -32,6 +32,17 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Fully-qualified image reference. image.flavor, when set, is appended to image.tag.
+*/}}
+{{- define "vaultwarden.image" -}}
+{{- $tag := .Values.image.tag -}}
+{{- if .Values.image.flavor -}}
+{{- $tag = printf "%s-%s" $tag .Values.image.flavor -}}
+{{- end -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "vaultwarden.labels" -}}

--- a/charts/vaultwarden/templates/_podSpec.tpl
+++ b/charts/vaultwarden/templates/_podSpec.tpl
@@ -34,7 +34,7 @@ initContainers:
 enableServiceLinks: false
 {{- end }}
 containers:
-  - image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+  - image: {{ include "vaultwarden.image" . }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
     name: vaultwarden
     envFrom:

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -10,10 +10,14 @@ image:
   ##
   repository: vaultwarden/server
   ##
-  ## @param image.tag Vaultwarden image tag
+  ## @param image.tag Vaultwarden image tag, without the flavor suffix
   ## Ref: https://hub.docker.com/r/vaultwarden/server/tags
   ##
-  tag: "1.37.2-alpine"
+  tag: "1.37.2"
+  ##
+  ## @param image.flavor Image flavor, appended to `image.tag`. Set to `""` for the Debian (glibc) image
+  ##
+  flavor: "alpine"
   ## @param image.pullPolicy Vaultwarden image pull policy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
## What

Splits the image flavor suffix out of `image.tag` into a new `image.flavor` value, appended to the tag when set.

```yaml
image:
  tag: "1.37.2"
  flavor: "alpine"   # "" for the Debian (glibc) image
```

## Why

Upstream `dani-garcia/vaultwarden` publishes an Alpine (musl) and a Debian (glibc) image for every release, but the chart baked `-alpine` into the `image.tag` default. Selecting the Debian image therefore meant overriding the full tag and re-pinning the version by hand on every upgrade — the flavor choice and the version pin were coupled when they're independent concerns.

The Debian image matters in practice: on clusters with a long DNS search list, musl's `getaddrinfo()` doesn't reliably fall through to the absolute name for hostnames under `ndots`, so outbound lookups (SSO/OIDC discovery, SMTP) fail from the Alpine image while the Debian one works. Today the only way to opt out is to hardcode a tag and remember to bump it.

## Effect on defaults

None. `tag: "1.37.2"` + `flavor: "alpine"` renders `docker.io/vaultwarden/server:1.37.2-alpine`, byte-identical to 0.46.1.

Verified with `helm template`:

| values | rendered |
| --- | --- |
| defaults | `docker.io/vaultwarden/server:1.37.2-alpine` |
| `flavor: ""` | `docker.io/vaultwarden/server:1.37.2` |
| `tag: 1.36.0` | `docker.io/vaultwarden/server:1.36.0-alpine` |
| `resourceType: StatefulSet` | `docker.io/vaultwarden/server:1.37.2-alpine` |

## Breaking change

`image.tag` no longer carries the flavor suffix. Anyone pinning a full tag like `1.37.1-alpine` must drop the suffix and set `image.flavor`, or the suffix is applied twice. Chart version bumped `0.46.1` → `0.47.0` and the upgrade is noted in the README.

Happy to invert this to a non-breaking form (default `flavor: ""`, leave `tag: "1.37.2-alpine"`) if you'd rather not break existing pins — it costs the feature its usefulness from the shipped defaults, but it's a one-line change.

## Notes

- `image.registry` / `image.repository` defaults are untouched.
- `ci/test-values.yaml` now sets `flavor: ""` so the non-default path is install-tested at no extra CI cost.
- README regenerated by hand (no Docker available locally) — please re-run `./generate-readme.sh` if the formatting drifts.
- `helm lint` passes.
